### PR TITLE
Add authentication views (Login, SignUp, ForgotPassword)

### DIFF
--- a/Views/Components/Auth/ForgotPasswordView.swift
+++ b/Views/Components/Auth/ForgotPasswordView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct ForgotPasswordView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 32) {
+                Spacer().frame(height: 40)
+
+                if authViewModel.forgotPasswordSent {
+                    // Success state
+                    VStack(spacing: 24) {
+                        ZStack {
+                            Circle()
+                                .fill(AppColors.success.opacity(0.1))
+                                .frame(width: 100, height: 100)
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: 48))
+                                .foregroundColor(AppColors.success)
+                        }
+
+                        Text("Correo Enviado")
+                            .font(AppTypography.titleFont)
+
+                        Text("Hemos enviado instrucciones para restablecer tu contraseña a \(authViewModel.forgotPasswordEmail)")
+                            .font(AppTypography.bodyFont)
+                            .foregroundColor(AppColors.textSecondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 32)
+
+                        Button(action: {
+                            authViewModel.forgotPasswordSent = false
+                            authViewModel.forgotPasswordEmail = ""
+                            dismiss()
+                        }) {
+                            Text("Volver al inicio de sesión")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .padding(.horizontal, 24)
+                    }
+                } else {
+                    // Form state
+                    VStack(spacing: 24) {
+                        ZStack {
+                            Circle()
+                                .fill(AppColors.primary.opacity(0.1))
+                                .frame(width: 80, height: 80)
+                            Image(systemName: "lock.rotation")
+                                .font(.system(size: 36))
+                                .foregroundColor(AppColors.primary)
+                        }
+
+                        VStack(spacing: 8) {
+                            Text("Recuperar Contraseña")
+                                .font(AppTypography.titleFont)
+
+                            Text("Ingresa tu correo electrónico y te enviaremos instrucciones para restablecer tu contraseña")
+                                .font(AppTypography.calloutFont)
+                                .foregroundColor(AppColors.textSecondary)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 24)
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Correo electrónico")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+
+                            HStack {
+                                Image(systemName: "envelope")
+                                    .foregroundColor(AppColors.textTertiary)
+                                TextField("tu@correo.com", text: $authViewModel.forgotPasswordEmail)
+                                    .keyboardType(.emailAddress)
+                                    .autocapitalization(.none)
+                                    .autocorrectionDisabled()
+                            }
+                            .padding(14)
+                            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .padding(.horizontal, 24)
+
+                        if let error = authViewModel.forgotPasswordError {
+                            Text(error)
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.error)
+                        }
+
+                        Button(action: {
+                            hideKeyboard()
+                            authViewModel.sendPasswordReset()
+                        }) {
+                            Text("Enviar Instrucciones")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .padding(.horizontal, 24)
+                        .disabled(authViewModel.forgotPasswordEmail.isEmpty)
+                    }
+                }
+
+                Spacer()
+            }
+            .background(Color(.systemBackground))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark")
+                            .foregroundColor(AppColors.textPrimary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Views/Components/Auth/LoginView.swift
+++ b/Views/Components/Auth/LoginView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var showSignUp = false
+    @State private var showForgotPassword = false
+    @State private var showPassword = false
+
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 32) {
+                    Spacer().frame(height: 40)
+
+                    // Logo
+                    VStack(spacing: 12) {
+                        ZStack {
+                            Circle()
+                                .fill(AppColors.primary.opacity(0.1))
+                                .frame(width: 80, height: 80)
+                            Image(systemName: "shippingbox.fill")
+                                .font(.system(size: 36))
+                                .foregroundColor(AppColors.primary)
+                        }
+
+                        Text("InventarIA")
+                            .font(AppTypography.largeTitleFont)
+                            .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+
+                        Text("Gestión inteligente de inventario")
+                            .font(AppTypography.calloutFont)
+                            .foregroundColor(AppColors.textSecondary)
+                    }
+
+                    // Form
+                    VStack(spacing: 20) {
+                        // Email
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Correo electrónico")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+
+                            HStack {
+                                Image(systemName: "envelope")
+                                    .foregroundColor(AppColors.textTertiary)
+                                TextField("tu@correo.com", text: $authViewModel.loginEmail)
+                                    .keyboardType(.emailAddress)
+                                    .textContentType(.emailAddress)
+                                    .autocapitalization(.none)
+                                    .autocorrectionDisabled()
+                            }
+                            .padding(14)
+                            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+
+                        // Password
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Contraseña")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+
+                            HStack {
+                                Image(systemName: "lock")
+                                    .foregroundColor(AppColors.textTertiary)
+
+                                if showPassword {
+                                    TextField("••••••••", text: $authViewModel.loginPassword)
+                                        .textContentType(.password)
+                                } else {
+                                    SecureField("••••••••", text: $authViewModel.loginPassword)
+                                        .textContentType(.password)
+                                }
+
+                                Button(action: { showPassword.toggle() }) {
+                                    Image(systemName: showPassword ? "eye.slash" : "eye")
+                                        .foregroundColor(AppColors.textTertiary)
+                                }
+                            }
+                            .padding(14)
+                            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+
+                        // Forgot password
+                        HStack {
+                            Spacer()
+                            Button("¿Olvidaste tu contraseña?") {
+                                showForgotPassword = true
+                            }
+                            .font(AppTypography.captionFont)
+                            .foregroundColor(AppColors.primary)
+                        }
+
+                        // Error message
+                        if let error = authViewModel.loginError {
+                            HStack {
+                                Image(systemName: "exclamationmark.circle.fill")
+                                    .foregroundColor(AppColors.error)
+                                Text(error)
+                                    .font(AppTypography.captionFont)
+                                    .foregroundColor(AppColors.error)
+                            }
+                            .padding(12)
+                            .background(AppColors.error.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+
+                        // Login button
+                        Button(action: {
+                            hideKeyboard()
+                            authViewModel.login()
+                        }) {
+                            if authViewModel.isLoggingIn {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("Iniciar Sesión")
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(!authViewModel.isLoginValid || authViewModel.isLoggingIn)
+                    }
+                    .padding(.horizontal, 24)
+
+                    // Sign up link
+                    HStack {
+                        Text("¿No tienes cuenta?")
+                            .font(AppTypography.calloutFont)
+                            .foregroundColor(AppColors.textSecondary)
+                        Button("Crear cuenta") {
+                            showSignUp = true
+                        }
+                        .font(AppTypography.calloutFont)
+                        .fontWeight(.semibold)
+                        .foregroundColor(AppColors.primary)
+                    }
+
+                    Spacer().frame(height: 20)
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .background(Color(.systemBackground))
+            .sheet(isPresented: $showSignUp) {
+                SignUpView()
+            }
+            .sheet(isPresented: $showForgotPassword) {
+                ForgotPasswordView()
+            }
+        }
+    }
+}

--- a/Views/Components/Auth/SignUpView.swift
+++ b/Views/Components/Auth/SignUpView.swift
@@ -1,0 +1,198 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @EnvironmentObject var authViewModel: AuthViewModel
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) var colorScheme
+    @State private var showPassword = false
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    // Header
+                    VStack(spacing: 8) {
+                        Text("Crear Cuenta")
+                            .font(AppTypography.titleFont)
+
+                        Text("Completa tus datos para comenzar")
+                            .font(AppTypography.calloutFont)
+                            .foregroundColor(AppColors.textSecondary)
+                    }
+                    .padding(.top, 20)
+
+                    VStack(spacing: 18) {
+                        // Full name
+                        formField(
+                            label: "Nombre completo",
+                            icon: "person",
+                            placeholder: "Tu nombre completo",
+                            text: $authViewModel.signUpName
+                        )
+
+                        // Email
+                        formField(
+                            label: "Correo electrónico",
+                            icon: "envelope",
+                            placeholder: "tu@correo.com",
+                            text: $authViewModel.signUpEmail,
+                            keyboardType: .emailAddress
+                        )
+
+                        // Password
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Contraseña")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+
+                            HStack {
+                                Image(systemName: "lock")
+                                    .foregroundColor(AppColors.textTertiary)
+                                if showPassword {
+                                    TextField("Mínimo 8 caracteres", text: $authViewModel.signUpPassword)
+                                } else {
+                                    SecureField("Mínimo 8 caracteres", text: $authViewModel.signUpPassword)
+                                }
+                                Button(action: { showPassword.toggle() }) {
+                                    Image(systemName: showPassword ? "eye.slash" : "eye")
+                                        .foregroundColor(AppColors.textTertiary)
+                                }
+                            }
+                            .padding(14)
+                            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                            if !authViewModel.signUpPassword.isEmpty && !authViewModel.passwordLengthValid {
+                                Text("La contraseña debe tener al menos 8 caracteres")
+                                    .font(AppTypography.caption2Font)
+                                    .foregroundColor(AppColors.error)
+                            }
+                        }
+
+                        // Confirm password
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Confirmar contraseña")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+
+                            HStack {
+                                Image(systemName: "lock.fill")
+                                    .foregroundColor(AppColors.textTertiary)
+                                SecureField("Repite tu contraseña", text: $authViewModel.signUpConfirmPassword)
+                            }
+                            .padding(14)
+                            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                            if !authViewModel.signUpConfirmPassword.isEmpty && !authViewModel.passwordsMatch {
+                                Text("Las contraseñas no coinciden")
+                                    .font(AppTypography.caption2Font)
+                                    .foregroundColor(AppColors.error)
+                            }
+                        }
+
+                        // Store name
+                        formField(
+                            label: "Nombre de tu tienda",
+                            icon: "storefront",
+                            placeholder: "Mi Tienda",
+                            text: $authViewModel.signUpStoreName
+                        )
+
+                        // Terms
+                        HStack(alignment: .top, spacing: 10) {
+                            Button(action: {
+                                authViewModel.signUpAcceptedTerms.toggle()
+                                HapticManager.impact(.light)
+                            }) {
+                                Image(systemName: authViewModel.signUpAcceptedTerms ? "checkmark.square.fill" : "square")
+                                    .font(.system(size: 22))
+                                    .foregroundColor(authViewModel.signUpAcceptedTerms ? AppColors.primary : AppColors.textTertiary)
+                            }
+
+                            Text("Acepto los términos y condiciones y la política de privacidad")
+                                .font(AppTypography.captionFont)
+                                .foregroundColor(AppColors.textSecondary)
+                        }
+
+                        // Error
+                        if let error = authViewModel.signUpError {
+                            HStack {
+                                Image(systemName: "exclamationmark.circle.fill")
+                                    .foregroundColor(AppColors.error)
+                                Text(error)
+                                    .font(AppTypography.captionFont)
+                                    .foregroundColor(AppColors.error)
+                            }
+                            .padding(12)
+                            .background(AppColors.error.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        }
+
+                        // Sign up button
+                        Button(action: {
+                            hideKeyboard()
+                            authViewModel.signUp()
+                        }) {
+                            if authViewModel.isSigningUp {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("Crear Cuenta")
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(!authViewModel.isSignUpValid || authViewModel.isSigningUp)
+                    }
+                    .padding(.horizontal, 24)
+
+                    // Login link
+                    HStack {
+                        Text("¿Ya tienes cuenta?")
+                            .font(AppTypography.calloutFont)
+                            .foregroundColor(AppColors.textSecondary)
+                        Button("Iniciar sesión") {
+                            dismiss()
+                        }
+                        .font(AppTypography.calloutFont)
+                        .fontWeight(.semibold)
+                        .foregroundColor(AppColors.primary)
+                    }
+                    .padding(.bottom, 20)
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .background(Color(.systemBackground))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark")
+                            .foregroundColor(AppColors.textPrimary)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func formField(label: String, icon: String, placeholder: String, text: Binding<String>, keyboardType: UIKeyboardType = .default) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+
+            HStack {
+                Image(systemName: icon)
+                    .foregroundColor(AppColors.textTertiary)
+                TextField(placeholder, text: text)
+                    .keyboardType(keyboardType)
+                    .autocapitalization(keyboardType == .emailAddress ? .none : .words)
+                    .autocorrectionDisabled()
+            }
+            .padding(14)
+            .background(colorScheme == .dark ? AppColors.darkSurfaceSecondary : AppColors.surfaceSecondary)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add the three auth screens: login, sign up and forgot password
- Each view binds to `AuthViewModel` for form state, validation and error handling
- Follows the app's theme system (AppColors, AppTypography)

## Changes
- `Views/Components/Auth/LoginView.swift`
- `Views/Components/Auth/SignUpView.swift`
- `Views/Components/Auth/ForgotPasswordView.swift`

## Test plan
- [x] Login form validates email/password and shows errors
- [x] Sign up form creates account and navigates to main
- [x] Forgot password sends reset email and shows confirmation
- [x] All views render correctly in light and dark mode