### PR TITLE
Add Analytics and Sales repositories

### DIFF
--- a/Services/Repositories/AnalyticsRepository.swift
+++ b/Services/Repositories/AnalyticsRepository.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+protocol AnalyticsRepositoryProtocol {
+    func fetchDashboard() async throws -> DashboardStats
+    func fetchSalesTrend(days: Int) async throws -> [SalesDataPoint]
+    func fetchStockByCategory() async throws -> [StockLevelData]
+    func fetchMargins() async throws -> [CategoryDistribution]
+    func exportReport(type: String, format: String, dateFrom: String?, dateTo: String?) async throws -> ExportResponseDTO
+}
+
+final class AnalyticsRepository: AnalyticsRepositoryProtocol {
+    private let apiClient = APIClient.shared
+    private let networkMonitor = NetworkMonitor.shared
+
+    func fetchDashboard() async throws -> DashboardStats {
+        guard networkMonitor.isConnected else {
+            // Compute from cached products
+            let products = PersistenceService.shared.loadProducts()
+            let alerts = PersistenceService.shared.loadAlerts()
+            return DashboardStats(
+                totalProducts: products.count,
+                lowStockCount: products.filter { $0.stockStatus == .lowStock }.count,
+                outOfStockCount: products.filter { $0.stockStatus == .outOfStock }.count,
+                totalStockValue: products.reduce(0) { $0 + $1.stockValue },
+                totalSalesToday: 0,
+                totalOrders: 0,
+                expiringCount: products.filter { $0.isExpiringSoon }.count,
+                activeAlerts: alerts.filter { !$0.isRead }.count
+            )
+        }
+
+        let dto: DashboardDTO = try await apiClient.request(.analyticsDashboard)
+        return dto.toDomain()
+    }
+
+    func fetchSalesTrend(days: Int = 30) async throws -> [SalesDataPoint] {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        print("[AnalyticsRepo] Fetching sales trend for \(days) days...")
+        let dtos: [SalesTrendItemDTO] = try await apiClient.request(
+            .analyticsSalesTrend,
+            queryParams: ["days": String(days)]
+        )
+        print("[AnalyticsRepo] Got \(dtos.count) sales trend DTOs")
+        if let first = dtos.first {
+            print("[AnalyticsRepo] Sample: date=\(first.date ?? "nil"), sales=\(first.sales ?? -1), revenue=\(first.revenue ?? -1)")
+        }
+        return dtos.map { $0.toDomain() }
+    }
+
+    func fetchStockByCategory() async throws -> [StockLevelData] {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        print("[AnalyticsRepo] Fetching stock by category...")
+        let dtos: [StockByCategoryDTO] = try await apiClient.request(.analyticsStockByCategory)
+        print("[AnalyticsRepo] Got \(dtos.count) stock category DTOs")
+        for dto in dtos {
+            print("[AnalyticsRepo] Category: \(dto.category ?? dto.categoryId ?? "nil"), totalStock=\(dto.totalStock ?? -1), productCount=\(dto.productCount ?? -1)")
+        }
+        return dtos.map { $0.toDomain() }
+    }
+
+    func fetchMargins() async throws -> [CategoryDistribution] {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        print("[AnalyticsRepo] Fetching margins (via stock-by-category)...")
+        // Use stock-by-category data to build category distribution (grouped, not per-product)
+        let dtos: [StockByCategoryDTO] = try await apiClient.request(.analyticsStockByCategory)
+        print("[AnalyticsRepo] Got \(dtos.count) DTOs for category distribution")
+        let totalCount = dtos.reduce(0) { $0 + ($1.productCount ?? $1.totalStock ?? $1.inStock ?? 0) }
+        return dtos.map { dto in
+            let count = dto.productCount ?? dto.totalStock ?? dto.inStock ?? 0
+            let name = dto.category ?? dto.categoryId ?? "Otros"
+            // Capitalize first letter for display
+            let displayName = name.prefix(1).uppercased() + name.dropFirst()
+            return CategoryDistribution(
+                category: displayName,
+                count: count,
+                percentage: totalCount > 0 ? (Double(count) / Double(totalCount)) * 100 : 0,
+                value: dto.totalValue ?? Double(count)
+            )
+        }
+    }
+
+    func exportReport(type: String, format: String, dateFrom: String? = nil, dateTo: String? = nil) async throws -> ExportResponseDTO {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        var body: [String: Any] = [
+            "type": type,
+            "format": format
+        ]
+        if let dateFrom { body["dateFrom"] = dateFrom }
+        if let dateTo { body["dateTo"] = dateTo }
+
+        return try await apiClient.request(
+            .exports,
+            method: .POST,
+            body: body
+        )
+    }
+}

--- a/Services/Repositories/SalesRepository.swift
+++ b/Services/Repositories/SalesRepository.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+protocol SalesRepositoryProtocol {
+    func recordSale(productId: String, quantity: Int, unitPrice: Double) async throws
+    func fetchSales(limit: Int?, cursor: String?) async throws -> (sales: [SaleRecordDTO], nextCursor: String?)
+    func fetchSummary(period: String, dateFrom: String?, dateTo: String?) async throws -> SalesSummaryDTO
+}
+
+/// Sale record DTO from backend
+struct SaleRecordDTO: Decodable {
+    let id: String
+    let storeId: String?
+    let productId: String?
+    let userId: String?
+    let quantity: Int
+    let unitPrice: Double
+    let totalAmount: Double
+    let createdAt: FirestoreTimestamp?
+}
+
+final class SalesRepository: SalesRepositoryProtocol {
+    private let apiClient = APIClient.shared
+    private let networkMonitor = NetworkMonitor.shared
+
+    func recordSale(productId: String, quantity: Int, unitPrice: Double) async throws {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        let body: [String: Any] = [
+            "productId": productId,
+            "quantity": quantity,
+            "unitPrice": unitPrice
+        ]
+
+        let _: SaleRecordDTO = try await apiClient.request(
+            .sales,
+            method: .POST,
+            body: body
+        )
+    }
+
+    func fetchSales(limit: Int? = nil, cursor: String? = nil) async throws -> (sales: [SaleRecordDTO], nextCursor: String?) {
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
+        }
+
+        var params: [String: String] = [:]
+        if let limit { params["limit"] = String(limit) }
+        if let cursor { params["startAfter"] = cursor }
+
+        let (dtos, pagination): ([SaleRecordDTO], APIPagination?) = try await apiClient.requestPaginated(
+            .sales,
+            queryParams: params.isEmpty ? nil : params
+        )
+
+        return (dtos, pagination?.nextCursor)
+    }
+
+    func fetchSummary(period: String = "day", dateFrom: String? = nil, dateTo: String? = nil) async throws -> SalesSummaryDTO {
+        var params: [String: String] = ["period": period]
+        if let dateFrom { params["dateFrom"] = dateFrom }
+        if let dateTo { params["dateTo"] = dateTo }
+
+        return try await apiClient.request(
+            .salesSummary,
+            queryParams: params
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AnalyticsRepository` to fetch dashboard metrics from the backend
- Add `SalesRepository` to fetch sales data for charts and reports
- Both use the networking layer and map DTOs to domain models

## Changes
- `Services/Repositories/AnalyticsRepository.swift`
- `Services/Repositories/SalesRepository.swift`

## Test plan
- [x] Analytics endpoint returns parsed metrics
- [x] Sales endpoint returns parsed data points
- [x] Errors propagate correctly through `APIError`