### PR TITLE
Fix xcodegen sources list and Firebase Auth keychain access

### DIFF
--- a/InventarIA.entitlements
+++ b/InventarIA.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.inventaria.app</string>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -28,15 +28,15 @@ targets:
     type: application
     platform: iOS
     sources:
-      - path: .
-        excludes:
-          - "project.yml"
-          - ".git"
-          - "**/.DS_Store"
-          - "*.xcodeproj"
-          - "build"
-          - "DerivedData"
-          - ".*"
+      - InventarIAApp.swift
+      - ContentView.swift
+      - Models
+      - Services
+      - Theme
+      - Utils
+      - ViewModels
+      - Views
+      - Assets.xcassets
       - path: GoogleService-Info.plist
         buildPhase: resources
     settings:

--- a/project.yml
+++ b/project.yml
@@ -48,9 +48,11 @@ targets:
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         DEVELOPMENT_TEAM: ""
         GENERATE_INFOPLIST_FILE: YES
-        CODE_SIGN_IDENTITY: ""
-        CODE_SIGNING_REQUIRED: "NO"
-        CODE_SIGNING_ALLOWED: "NO"
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGNING_REQUIRED: "YES"
+        CODE_SIGNING_ALLOWED: "YES"
+        CODE_SIGN_STYLE: Manual
+        CODE_SIGN_ENTITLEMENTS: InventarIA.entitlements
     dependencies:
       - package: Firebase
         product: FirebaseAuth


### PR DESCRIPTION
## Summary

Two follow-up fixes to the initial xcodegen scaffolding. The previous setup built successfully but produced an unusable app: the binary had no compiled sources, and once that was fixed the sign-up flow failed at the Keychain step.

### 1. `fix(xcodegen): list source directories explicitly`

The exclude pattern `.*` was intended to skip hidden directories but xcodegen's glob matched every file under the project root, leaving the Sources build phase empty. The app linked with no `@main` entry point:

```
Undefined symbol: _main
Linker command failed with exit code 1
```

Replaced `path: .` + excludes with an explicit list of top-level entries (`InventarIAApp.swift`, `ContentView.swift`, `Models`, `Services`, `Theme`, `Utils`, `ViewModels`, `Views`, `Assets.xcassets`, `GoogleService-Info.plist`). No wildcards, no hidden-directory edge cases.

### 2. `fix(auth): add keychain entitlements so Firebase Auth can persist sessions`

After the linker fix the app ran but signup failed with:

> Error al crear la cuenta: An error occurred when accessing the keychain.

Firebase Auth stores the current user and refresh token in the iOS Keychain. Without an application identifier prefix, `SecItemAdd` returns `errSecMissingEntitlement`.

- Added `InventarIA.entitlements` with `keychain-access-groups = $(AppIdentifierPrefix)com.inventaria.app`.
- Flipped `CODE_SIGNING_ALLOWED` / `CODE_SIGNING_REQUIRED` to `YES` and set `CODE_SIGN_IDENTITY = "-"` (ad-hoc) so the Simulator can pick up the entitlements.
- Pointed `CODE_SIGN_ENTITLEMENTS` at the new file.

Ad-hoc signing is enough for the iOS Simulator. Running on a physical device will still require a real `DEVELOPMENT_TEAM` to be filled in.

## Verification

- [x] `xcodegen generate` produces a project with 124 Swift files in the Sources build phase
- [x] `xcodebuild ... clean build` succeeds on iPhone 16e simulator (Xcode 26.3)
- [x] Installed and launched on simulator — onboarding screen renders, no crash at `FirebaseApp.configure()`
- [x] Generated `Entitlements-Simulated.plist` contains `keychain-access-groups` with the team prefix
- [x] Backend health check: `GET https://us-central1-inventaria-app-ae5ce.cloudfunctions.net/api/health` returns HTTP 200
- [ ] End-to-end signup flow — to be confirmed manually by creating a test account from the simulator