### PR TITLE
add PipelineLogger and AnalyticsLogService for analytics feature

### DIFF
--- a/Services/Analytics/AnalyticsEvent.swift
+++ b/Services/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct AnalyticsEvent: Codable, Identifiable, Hashable {
+    let id: UUID
+    let kind: Kind
+    let timestamp: Date
+    let attributes: [String: String]
+
+    enum Kind: String, Codable, CaseIterable {
+        case screenViewed
+
+        case scanAttempt
+
+        case featureAccessed
+    }
+
+    init(kind: Kind, timestamp: Date = Date(), attributes: [String: String] = [:]) {
+        self.id = UUID()
+        self.kind = kind
+        self.timestamp = timestamp
+        self.attributes = attributes
+    }
+
+    var hourOfDay: Int { Calendar.current.component(.hour, from: timestamp) }
+
+    var isoWeek: Int {
+        Calendar.current.component(.weekOfYear, from: timestamp)
+    }
+}

--- a/Services/Analytics/AnalyticsLogService.swift
+++ b/Services/Analytics/AnalyticsLogService.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+actor AnalyticsLogService {
+    static let shared = AnalyticsLogService()
+
+    private let fileName = "analytics_events.json"
+    private let maxEvents = 5_000
+
+    private var events: [AnalyticsEvent] = []
+    private var loaded = false
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let fileManager = FileManager.default
+
+    private init() {
+        encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func record(_ event: AnalyticsEvent) {
+        loadIfNeeded()
+        events.append(event)
+        if events.count > maxEvents {
+            events.removeFirst(events.count - maxEvents / 2)
+        }
+        persist()
+    }
+
+    func record(kind: AnalyticsEvent.Kind, attributes: [String: String] = [:]) {
+        record(AnalyticsEvent(kind: kind, attributes: attributes))
+    }
+
+    func recentEvents(within days: Int = 30) -> [AnalyticsEvent] {
+        loadIfNeeded()
+        let cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
+        return events.filter { $0.timestamp >= cutoff }
+    }
+
+    func clear() {
+        events.removeAll()
+        let url = storageURL()
+        try? fileManager.removeItem(at: url)
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        defer { loaded = true }
+        let url = storageURL()
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        if let data = try? Data(contentsOf: url),
+           let decoded = try? decoder.decode([AnalyticsEvent].self, from: data) {
+            events = decoded
+        }
+    }
+
+    private func persist() {
+        let url = storageURL()
+        if let data = try? encoder.encode(events) {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func storageURL() -> URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        if !fileManager.fileExists(atPath: base.path) {
+            try? fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+        }
+        return base.appendingPathComponent(fileName)
+    }
+}

--- a/Services/Analytics/PipelineLogger.swift
+++ b/Services/Analytics/PipelineLogger.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct LatencySample: Codable, Hashable {
+    enum Stage: String, Codable, CaseIterable {
+        case ingestion
+        case storage
+        case processing
+        case computation
+    }
+
+    let stage: Stage
+    let durationMs: Double
+    let timestamp: Date
+}
+
+actor PipelineLogger {
+    static let shared = PipelineLogger()
+
+    struct Token {
+        let stage: LatencySample.Stage
+        let start: Date
+    }
+
+    private let fileName = "pipeline_latencies.json"
+    private var samples: [LatencySample] = []
+    private var loaded = false
+    private let cap = 2_000
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let fileManager = FileManager.default
+
+    private init() {
+        encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func start(_ stage: LatencySample.Stage) -> Token {
+        Token(stage: stage, start: Date())
+    }
+
+    func end(_ token: Token) {
+        loadIfNeeded()
+        let ms = Date().timeIntervalSince(token.start) * 1000
+        samples.append(LatencySample(stage: token.stage, durationMs: ms, timestamp: Date()))
+        if samples.count > cap { samples.removeFirst(samples.count - cap / 2) }
+        persist()
+    }
+
+    func recordExternal(stage: LatencySample.Stage, durationMs: Double) {
+        loadIfNeeded()
+        samples.append(LatencySample(stage: stage, durationMs: durationMs, timestamp: Date()))
+        if samples.count > cap { samples.removeFirst(samples.count - cap / 2) }
+        persist()
+    }
+
+    func recentSamples(within days: Int = 30) -> [LatencySample] {
+        loadIfNeeded()
+        let cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
+        return samples.filter { $0.timestamp >= cutoff }
+    }
+
+    func clear() {
+        samples.removeAll()
+        let url = storageURL()
+        try? fileManager.removeItem(at: url)
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        defer { loaded = true }
+        let url = storageURL()
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        if let data = try? Data(contentsOf: url),
+           let decoded = try? decoder.decode([LatencySample].self, from: data) {
+            samples = decoded
+        }
+    }
+
+    private func persist() {
+        let url = storageURL()
+        if let data = try? encoder.encode(samples) {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func storageURL() -> URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        if !fileManager.fileExists(atPath: base.path) {
+            try? fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+        }
+        return base.appendingPathComponent(fileName)
+    }
+}


### PR DESCRIPTION
Both services are actors with append only JSON files persistence in Application Support. PipelineLogger feeds BQ1 by recording LatencySamples per pipeline stage. AnalyticsLogService feeds BQ5/BQ7/BQ8 with screenViewed / scanAttempt / featureAccessed events.