### PR TITLE
add Sprint3 BQ view-model, cards and Analytics entry point

### DIFF
--- a/ViewModels/BQ/Sprint3BQsViewModel.swift
+++ b/ViewModels/BQ/Sprint3BQsViewModel.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class Sprint3BQsViewModel: ObservableObject {
+
+    @Published private(set) var latency: LatencySummary?
+    @Published private(set) var peakScreens: PeakScreensSummary?
+    @Published private(set) var scanAccuracy: ScanAccuracySummary?
+    @Published private(set) var featureUsage: FeatureUsageSummary?
+
+    @Published private(set) var isLoading = false
+    @Published private(set) var errorMessage: String?
+
+    private let logger = PipelineLogger.shared
+    private let events = AnalyticsLogService.shared
+    private let cache = BQCacheService.shared
+
+    func refresh(forceFresh: Bool = false) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        async let l = computeLatency(forceFresh: forceFresh)
+        async let p = computePeakScreens(forceFresh: forceFresh)
+        async let s = computeScanAccuracy(forceFresh: forceFresh)
+        async let f = computeFeatureUsage(forceFresh: forceFresh)
+        let (lv, pv, sv, fv) = await (l, p, s, f)
+
+        self.latency = lv
+        self.peakScreens = pv
+        self.scanAccuracy = sv
+        self.featureUsage = fv
+    }
+
+
+    private func computeLatency(forceFresh: Bool) async -> LatencySummary {
+        if !forceFresh,
+           let cached: CachedLatency = await cache.get(CachedLatency.self, for: .latencySummary) {
+            return cached.value
+        }
+        let samples = await logger.recentSamples()
+        let summary = await DataProcessingService.averageLatencies(samples: samples)
+        await cache.put(CachedLatency(value: summary), for: .latencySummary)
+        return summary
+    }
+
+    private func computePeakScreens(forceFresh: Bool) async -> PeakScreensSummary {
+        if !forceFresh,
+           let cached: CachedPeakScreens = await cache.get(CachedPeakScreens.self, for: .peakScreensSummary) {
+            return cached.value
+        }
+        let recent = await events.recentEvents()
+        let summary = await DataProcessingService.peakScreens(events: recent)
+        await cache.put(CachedPeakScreens(value: summary), for: .peakScreensSummary)
+        return summary
+    }
+
+    private func computeScanAccuracy(forceFresh _: Bool) async -> ScanAccuracySummary {
+        let recent = await events.recentEvents()
+        return await DataProcessingService.scanAccuracy(events: recent)
+    }
+
+    private func computeFeatureUsage(forceFresh _: Bool) async -> FeatureUsageSummary {
+        let recent = await events.recentEvents()
+        return await DataProcessingService.featureUsage(events: recent)
+    }
+}
+
+
+private struct CachedLatency: Codable {
+    let stages: [CodableStageStat]
+    let totalSamples: Int
+    let overallAverageMs: Double
+    let computedAt: Date
+    let durationMs: Double
+
+    init(value: LatencySummary) {
+        stages = value.stages.map { CodableStageStat(stage: $0.stage.rawValue, count: $0.count, averageMs: $0.averageMs) }
+        totalSamples = value.totalSamples
+        overallAverageMs = value.overallAverageMs
+        computedAt = value.computedAt
+        durationMs = value.durationMs
+    }
+
+    var value: LatencySummary {
+        LatencySummary(
+            stages: stages.map { StageStat(stage: .init(rawValue: $0.stage) ?? .ingestion,
+                                           count: $0.count,
+                                           averageMs: $0.averageMs) },
+            totalSamples: totalSamples,
+            overallAverageMs: overallAverageMs,
+            computedAt: computedAt,
+            durationMs: durationMs
+        )
+    }
+}
+
+private struct CodableStageStat: Codable {
+    let stage: String
+    let count: Int
+    let averageMs: Double
+}
+
+private struct CachedPeakScreens: Codable {
+    let rows: [Row]
+    let computedAt: Date
+    let durationMs: Double
+
+    struct Row: Codable {
+        let screen: String
+        let total: Int
+        let peakHour: Int
+        let peakHourCount: Int
+    }
+
+    init(value: PeakScreensSummary) {
+        rows = value.rows.map { .init(screen: $0.screen, total: $0.total, peakHour: $0.peakHour, peakHourCount: $0.peakHourCount) }
+        computedAt = value.computedAt
+        durationMs = value.durationMs
+    }
+
+    var value: PeakScreensSummary {
+        PeakScreensSummary(
+            rows: rows.map { ScreenPeak(screen: $0.screen, total: $0.total, peakHour: $0.peakHour, peakHourCount: $0.peakHourCount) },
+            computedAt: computedAt,
+            durationMs: durationMs
+        )
+    }
+}

--- a/Views/Analytics/Insights/BusinessQuestionsView.swift
+++ b/Views/Analytics/Insights/BusinessQuestionsView.swift
@@ -3,19 +3,16 @@ import Charts
 
 /// Sprint 3 Business Questions dashboard (Juan Felipe).
 ///
-/// Hosts two answer cards:
 ///   • BQ2 — Inventory valuation per store
 ///   • BQ6 — Peak hours at which the user adds products
 ///
-/// Both cards derive their data from local caches, so the screen is
-/// functional in airplane mode. A banner surfaces the current connectivity
-/// state so the user understands whether numbers reflect a freshly-synced
-/// catalog or the last offline snapshot.
+
 struct BusinessQuestionsView: View {
     @EnvironmentObject private var inventoryViewModel: InventoryViewModel
     @EnvironmentObject private var storeViewModel: StoreViewModel
 
     @StateObject private var viewModel = BusinessQuestionsViewModel()
+    @StateObject private var sprint3VM = Sprint3BQsViewModel()
     @ObservedObject private var network = NetworkMonitor.shared
 
     var body: some View {
@@ -31,6 +28,22 @@ struct BusinessQuestionsView: View {
                     summary: viewModel.peakActivity,
                     isLoading: viewModel.isLoadingPeak
                 )
+                PipelineLatencyCard(
+                    summary: sprint3VM.latency,
+                    isLoading: sprint3VM.isLoading
+                )
+                PeakScreensCard(
+                    summary: sprint3VM.peakScreens,
+                    isLoading: sprint3VM.isLoading
+                )
+                ScanAccuracyCard(
+                    summary: sprint3VM.scanAccuracy,
+                    isLoading: sprint3VM.isLoading
+                )
+                FeatureUsageCard(
+                    summary: sprint3VM.featureUsage,
+                    isLoading: sprint3VM.isLoading
+                )
                 Spacer().frame(height: 40)
             }
             .padding(.horizontal, 16)
@@ -44,7 +57,11 @@ struct BusinessQuestionsView: View {
             // When we transition online, re-run so the valuation picks up
             // anything the inventory sync pulled in.
             guard isConnected else { return }
-            Task { await refresh() }
+            Task { await sprint3VM.refresh()
+                await AnalyticsLogService.shared.record(
+                kind: .featureAccessed,
+                attributes: ["feature": "business_questions_screen"]
+            ) }
         }
     }
 

--- a/Views/Analytics/Insights/FeatureUsageCard.swift
+++ b/Views/Analytics/Insights/FeatureUsageCard.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// BQ8 
+struct FeatureUsageCard: View {
+    let summary: FeatureUsageSummary?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && summary == nil {
+                HStack { Spacer(); ProgressView().scaleEffect(0.7); Spacer() }
+            } else if let s = summary, !s.rows.isEmpty {
+                rows(s.rows)
+                footer(s)
+            } else if summary != nil {
+                empty
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(AppColors.surface)
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("BQ8 · Features analíticas más consultadas por semana")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(AppColors.inkBlack)
+            Text("Agregación off-main por feature × semana ISO")
+                .font(.caption2)
+                .foregroundColor(AppColors.textTertiary)
+        }
+    }
+
+    private func rows(_ items: [FeatureUsageRow]) -> some View {
+        VStack(spacing: 10) {
+            ForEach(items.prefix(6)) { row in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(row.feature)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundColor(AppColors.inkBlack)
+                        Text("\(row.weeklyCounts.count) semanas con actividad")
+                            .font(.caption2)
+                            .foregroundColor(AppColors.textTertiary)
+                    }
+                    Spacer()
+                    Text("\(row.totalAccesses)")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(AppColors.freshSky)
+                }
+            }
+        }
+    }
+
+    private func footer(_ s: FeatureUsageSummary) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "chart.bar.doc.horizontal").font(.caption2)
+            Text(String(format: "Calculado en %.1f ms", s.durationMs))
+                .font(.caption2)
+        }
+        .foregroundColor(AppColors.textTertiary)
+    }
+
+    private var empty: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "eye.slash")
+                    .font(.title2)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("No hay aún eventos de features registradas.")
+                    .font(.footnote)
+                    .foregroundColor(AppColors.textTertiary)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+}

--- a/Views/Analytics/Insights/PeakScreensCard.swift
+++ b/Views/Analytics/Insights/PeakScreensCard.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// BQ5 
+struct PeakScreensCard: View {
+    let summary: PeakScreensSummary?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && summary == nil {
+                loading
+            } else if let s = summary, !s.rows.isEmpty {
+                rows(s.rows)
+                footer(s)
+            } else if summary != nil {
+                empty
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(AppColors.surface)
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("BQ5 · Pantallas con más tráfico por hora pico")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(AppColors.inkBlack)
+            Text("Últimos 30 días · histograma por pantalla (isolate)")
+                .font(.caption2)
+                .foregroundColor(AppColors.textTertiary)
+        }
+    }
+
+    private func rows(_ items: [ScreenPeak]) -> some View {
+        VStack(spacing: 10) {
+            ForEach(items.prefix(6)) { item in
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(item.screen)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundColor(AppColors.inkBlack)
+                        Text("pico a las \(String(format: "%02d:00", item.peakHour))")
+                            .font(.caption2)
+                            .foregroundColor(AppColors.textTertiary)
+                    }
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("\(item.total)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(AppColors.freshSky)
+                        Text("visitas")
+                            .font(.caption2)
+                            .foregroundColor(AppColors.textTertiary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func footer(_ s: PeakScreensSummary) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "clock.arrow.circlepath").font(.caption2)
+            Text(String(format: "Calculado en %.1f ms", s.durationMs))
+                .font(.caption2)
+        }
+        .foregroundColor(AppColors.textTertiary)
+    }
+
+    private var empty: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "rectangle.stack")
+                    .font(.title2)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("Aún no se registra navegación entre pantallas.")
+                    .font(.footnote)
+                    .foregroundColor(AppColors.textTertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+
+    private var loading: some View {
+        HStack { Spacer(); ProgressView("Analizando…").font(.footnote); Spacer() }
+            .padding(.vertical, 24)
+    }
+}

--- a/Views/Analytics/Insights/PipelineLatencyCard.swift
+++ b/Views/Analytics/Insights/PipelineLatencyCard.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// BQ1 
+struct PipelineLatencyCard: View {
+    let summary: LatencySummary?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && summary == nil {
+                loadingRow
+            } else if let s = summary, s.totalSamples > 0 {
+                overall(s)
+                Divider()
+                stageRows(s.stages)
+                footer(s)
+            } else if summary != nil {
+                emptyState
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(AppColors.surface)
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("BQ1 · Latencia promedio del pipeline")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(AppColors.inkBlack)
+                Text("ingestion → storage → processing → computation")
+                    .font(.caption2)
+                    .foregroundColor(AppColors.textTertiary)
+            }
+            Spacer()
+            if isLoading { ProgressView().scaleEffect(0.7) }
+        }
+    }
+
+    private func overall(_ s: LatencySummary) -> some View {
+        HStack(spacing: 20) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Promedio global")
+                    .font(.caption)
+                    .foregroundColor(AppColors.textTertiary)
+                Text(String(format: "%.1f ms", s.overallAverageMs))
+                    .font(.title3.weight(.bold))
+                    .foregroundColor(AppColors.freshSky)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Muestras (30 días)")
+                    .font(.caption)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("\(s.totalSamples)")
+                    .font(.title3.weight(.bold))
+                    .foregroundColor(AppColors.inkBlack)
+            }
+            Spacer()
+        }
+    }
+
+    private func stageRows(_ stats: [StageStat]) -> some View {
+        VStack(spacing: 10) {
+            ForEach(stats) { stat in
+                HStack {
+                    Text(stat.stage.rawValue.capitalized)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundColor(AppColors.inkBlack)
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(String(format: "%.1f ms", stat.averageMs))
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(AppColors.inkBlack)
+                        Text("\(stat.count) muestras")
+                            .font(.caption2)
+                            .foregroundColor(AppColors.textTertiary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func footer(_ s: LatencySummary) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "bolt.fill").font(.caption2)
+            Text(String(format: "Calculado en %.1f ms (off-main)", s.durationMs))
+                .font(.caption2)
+        }
+        .foregroundColor(AppColors.textTertiary)
+    }
+
+    private var emptyState: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "gauge.with.needle")
+                    .font(.title2)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("Aún no hay muestras de latencia.")
+                    .font(.footnote)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("Crea o edita un producto para capturar samples.")
+                    .font(.caption2)
+                    .foregroundColor(AppColors.textTertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            ProgressView("Agregando samples…")
+                .font(.footnote)
+            Spacer()
+        }
+        .padding(.vertical, 24)
+    }
+}

--- a/Views/Analytics/Insights/ScanAccuracyCard.swift
+++ b/Views/Analytics/Insights/ScanAccuracyCard.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// BQ7 barcode scan vs manual entry accuracy
+struct ScanAccuracyCard: View {
+    let summary: ScanAccuracySummary?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && summary == nil {
+                HStack { Spacer(); ProgressView().scaleEffect(0.7); Spacer() }
+            } else if let s = summary, (s.cameraAttempts + s.manualAttempts) > 0 {
+                comparison(s)
+                footer(s)
+            } else if summary != nil {
+                empty
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(AppColors.surface)
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("BQ7 · Scan con cámara vs entrada manual")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(AppColors.inkBlack)
+            Text("Precisión de reconocimiento · últimos 30 días")
+                .font(.caption2)
+                .foregroundColor(AppColors.textTertiary)
+        }
+    }
+
+    private func comparison(_ s: ScanAccuracySummary) -> some View {
+        HStack(spacing: 20) {
+            accuracyBlock(
+                title: "Cámara",
+                accuracy: s.cameraAccuracy,
+                attempts: s.cameraAttempts,
+                tint: AppColors.freshSky
+            )
+            accuracyBlock(
+                title: "Manual",
+                accuracy: s.manualAccuracy,
+                attempts: s.manualAttempts,
+                tint: AppColors.teaGreen
+            )
+        }
+    }
+
+    private func accuracyBlock(title: String, accuracy: Double, attempts: Int, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(AppColors.textTertiary)
+            Text(String(format: "%.0f%%", accuracy * 100))
+                .font(.title2.weight(.bold))
+                .foregroundColor(tint)
+            ProgressView(value: accuracy)
+                .tint(tint)
+            Text("\(attempts) intentos")
+                .font(.caption2)
+                .foregroundColor(AppColors.textTertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func footer(_ s: ScanAccuracySummary) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "speedometer").font(.caption2)
+            Text(String(format: "Calculado en %.1f ms", s.durationMs))
+                .font(.caption2)
+        }
+        .foregroundColor(AppColors.textTertiary)
+    }
+
+    private var empty: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "barcode.viewfinder")
+                    .font(.title2)
+                    .foregroundColor(AppColors.textTertiary)
+                Text("Sin intentos de scan registrados todavía.")
+                    .font(.footnote)
+                    .foregroundColor(AppColors.textTertiary)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+}


### PR DESCRIPTION
Sprint3BQsViewModel runs the four analyses concurrently via async let, each delegating to DataProcessingService detached tasks. Results are cached through BQCacheService with per BQ TTLs. The Business Questions screen now shows Juan Felipe's two cards and the four cards done by me (Santiago).