### PR TITLE
Fix Sprint 3 build: unblock MainTabView, mount all 8 BQ cards

### DIFF
--- a/Views/Analytics/Insights/BusinessQuestionsView.swift
+++ b/Views/Analytics/Insights/BusinessQuestionsView.swift
@@ -13,6 +13,7 @@ struct BusinessQuestionsView: View {
 
     @StateObject private var viewModel = BusinessQuestionsViewModel()
     @StateObject private var sprint3VM = Sprint3BQsViewModel()
+    @StateObject private var insightsVM = InventoryInsightsViewModel()
     @ObservedObject private var network = NetworkMonitor.shared
 
     var body: some View {
@@ -44,6 +45,14 @@ struct BusinessQuestionsView: View {
                     summary: sprint3VM.featureUsage,
                     isLoading: sprint3VM.isLoading
                 )
+                RestockCyclesCard(
+                    dashboard: insightsVM.restockDashboard,
+                    isLoading: insightsVM.isLoadingRestock
+                )
+                ExpirationActionCard(
+                    dashboard: insightsVM.expirationDashboard,
+                    isLoading: insightsVM.isLoadingExpiration
+                )
                 Spacer().frame(height: 40)
             }
             .padding(.horizontal, 16)
@@ -65,6 +74,7 @@ struct BusinessQuestionsView: View {
             products: inventoryViewModel.products
         )
         await sprint3VM.refresh()
+        await insightsVM.refresh(products: inventoryViewModel.products)
         // BQ8
         await AnalyticsLogService.shared.record(
             kind: .featureAccessed,

--- a/Views/Components/Main/MainTabView.swift
+++ b/Views/Components/Main/MainTabView.swift
@@ -55,7 +55,7 @@ struct MainTabView: View {
                     selectedTab = .home
                 }
             }
-        }}
+        }
         .fullScreenCover(isPresented: $showScanSheet) {
             ScanView()
         }


### PR DESCRIPTION
## Summary

Post-merge audit of the Sprint 3 work surfaced two defects. Both were blocking a complete viva voce demo.

### 1. `fix(tabs): remove stray brace that was closing MainTabView.body too early`

`MainTabView.swift` had a `}}` at the end of the `.onChange(of: selectedTab)` closure, which silently terminated both the closure **and** the `body` computed property. That left `.fullScreenCover` and `.onAppear` as top-level stray modifiers, so `xcodebuild` rejected the file with:

```
MainTabView.swift:59:9: error: expected declaration
MainTabView.swift:121:1: error: extraneous '}' at top level
```

**This was breaking `main`.** Trimming the double brace to a single `}` gets the app compiling again.

### 2. `fix(bq): mount all eight Sprint 3 cards in the Business Questions screen`

`BusinessQuestionsView` was only mounting six of the eight Sprint 3 BQ cards (Juan Felipe's two + Santiago's four). Angel's two cards — `RestockCyclesCard` (BQ3) and `ExpirationActionCard` (BQ4) — existed as files but were never rendered, and `InventoryInsightsViewModel` was not even instantiated in the view.

Added `@StateObject var insightsVM = InventoryInsightsViewModel()`, appended the two missing cards after the existing six, and extended `refresh()` so Angel's view-model is refreshed alongside the other two on every entry and pull-to-refresh.

## Verification

- [x] `xcodegen generate && xcodebuild -project InventarIA.xcodeproj -scheme InventarIA -destination 'platform=iOS Simulator,name=iPhone 16e' -configuration Debug build ENABLE_PREVIEWS=NO` → `** BUILD SUCCEEDED **` (was failing before fix #1).
- [x] App installs and launches on the iPhone 16e simulator.
- [ ] Manual: login → Analytics → `?` in toolbar → 8 cards render in this order:
  1. BQ2 · Valor del inventario por tienda
  2. BQ6 · Hora pico para agregar productos
  3. BQ1 · Latencia promedio del pipeline
  4. BQ5 · Pantallas con más tráfico por hora pico
  5. BQ7 · Scan con cámara vs entrada manual
  6. BQ8 · Features analíticas más consultadas por semana
  7. BQ3 · Tiempo promedio de reposición
  8. BQ4 · Productos próximos a vencer · acciones sugeridas

## Sprint 3 coverage audit (for reference)

Each teammate independently implements the four Sprint 3 strategies:

| Member | BQs | Multi-threading | Local storage | Caching | Eventual connectivity |
|---|---|---|---|---|---|
| Juan Felipe | BQ2 + BQ6 | `TaskGroup` fan-out in `InventoryValuationService` + `Task.detached` in `PeakActivityAnalyzer` + `actor LRUCache` | `UsageTrackingService` JSON in Application Support | `actor LRUCache<Key, Value>` with per-entry TTL | Reads from local `products` + `UsageTrackingService`, banner from `NetworkMonitor`, invalidation on `.inventoryDidChange` |
| Santiago | BQ1 + BQ5 + BQ7 + BQ8 | Four `Task.detached(priority: .userInitiated)` functions in `DataProcessingService` + four `actor` services | `PipelineLogger`, `AnalyticsLogService`, `OfflineQueueService`, `BQCacheService` disk layer | Two-layer `BQCacheService` (LRU in memory + JSON on disk) with typed keys and per-resource TTLs | `ConnectivityService` + `OfflineQueueService` replaying queued mutations on reconnect; wired into `addProduct`, `updateProduct`, `deleteProduct`; bootstrapped at app launch |
| Angel | BQ3 + BQ4 | `TaskGroup` fan-out per product in `RestockCycleAnalyzer` and `ExpirationInsightsAnalyzer`; `actor RestockCycleStore` | `RestockCycleStore` JSON in Application Support | In-memory TTL cache inside `InventoryInsightsViewModel`, invalidation on `.inventoryDidChange` | Both BQs consume only local state, so they keep answering offline |