### PR TITLE
feat(storage): add SwiftData relational store with dual-write

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @State private var didBootstrap = false
 
     var body: some View {
         Group {
@@ -18,5 +19,14 @@ struct ContentView: View {
         }
         .animation(.easeInOut(duration: 0.3), value: authViewModel.hasCompletedOnboarding)
         .animation(.easeInOut(duration: 0.3), value: authViewModel.isAuthenticated)
+        .onAppear {
+            // BD relacional local: el bootstrap se hace desde la primera
+            // vista para asegurar que el `ModelContext` ya tiene su scene
+            // gráfico activo. Idempotente: sólo escribe la primera vez.
+            if !didBootstrap {
+                didBootstrap = true
+                LocalDatabaseService.shared.bootstrapLaunchEvent()
+            }
+        }
     }
 }

--- a/InventarIAApp.swift
+++ b/InventarIAApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 import FirebaseCore
 import UIKit
 
@@ -27,6 +28,13 @@ struct InventarIAApp: App {
 
         PersistenceService.shared.clearMockDataIfNeeded()
 
+        // Inicializa el container de SwiftData (BD Local Relacional). El
+        // `bootstrapLaunchEvent` se dispara desde `ContentView.onAppear`
+        // para garantizar que la scene ya está montada y `@MainActor` está
+        // disponible — algunos arranques de iOS 17 no programan tareas
+        // de App.init lo suficientemente rápido y se pierden.
+        _ = LocalDatabaseService.shared
+
         // offline nunca se replayean al volver la conexión
         OfflineQueueService.bootstrap(replayHandlers: .init(
             createProduct: { product in
@@ -51,6 +59,7 @@ struct InventarIAApp: App {
                 .environmentObject(analyticsViewModel)
                 .preferredColorScheme(settingsViewModel.isDarkMode ? .dark : .light)
                 .tint(AppColors.freshSky)
+                .modelContainer(LocalDatabaseService.shared.container)
         }
     }
 }

--- a/Models/LocalDatabase/AuditLogEntry.swift
+++ b/Models/LocalDatabase/AuditLogEntry.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuditLogEntry — tabla de auditoría persistida en el store relacional local.
+//
+// Llave foránea (relacional): `session` apunta a `UserSession`. Si el padre
+// se borra, la regla `cascade` declarada en `UserSession.auditEntries` se
+// encarga de limpiar también las entradas hijas.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Model
+final class AuditLogEntry {
+    @Attribute(.unique) var id: UUID
+    var action: String
+    var entityType: String
+    var entityId: UUID?
+    var entityName: String?
+    var details: String
+    var timestamp: Date
+
+    var session: UserSession?
+
+    init(id: UUID = UUID(),
+         action: String,
+         entityType: String,
+         entityId: UUID? = nil,
+         entityName: String? = nil,
+         details: String,
+         timestamp: Date = Date(),
+         session: UserSession? = nil) {
+        self.id = id
+        self.action = action
+        self.entityType = entityType
+        self.entityId = entityId
+        self.entityName = entityName
+        self.details = details
+        self.timestamp = timestamp
+        self.session = session
+    }
+}

--- a/Models/LocalDatabase/UsageEventRecord.swift
+++ b/Models/LocalDatabase/UsageEventRecord.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UsageEventRecord — versión SwiftData del log de uso. La fuente de verdad
+// para BQ6 sigue siendo `UsageTrackingService` (actor + JSON), pero cada
+// `record` ahora hace **dual-write** a esta tabla relacional para que la
+// misma información sea consultable con `@Query` y predicados desde la UI
+// (ver `LocalDatabaseDebugView`).
+//
+// `kind` se guarda como `String` porque SwiftData no soporta enums no-RawRepresentable
+// con asociados directamente; el valor crudo viene de `UsageEvent.Kind.rawValue`.
+// `attributesJSON` se serializa con `JSONEncoder` para preservar el payload libre.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Model
+final class UsageEventRecord {
+    @Attribute(.unique) var id: UUID
+    var kind: String
+    var timestamp: Date
+    var attributesJSON: String
+
+    var session: UserSession?
+
+    init(id: UUID = UUID(),
+         kind: String,
+         timestamp: Date = Date(),
+         attributesJSON: String = "{}",
+         session: UserSession? = nil) {
+        self.id = id
+        self.kind = kind
+        self.timestamp = timestamp
+        self.attributesJSON = attributesJSON
+        self.session = session
+    }
+
+    /// Hora del día en la zona horaria local — usada por BQ6 cuando los datos
+    /// se reconstruyen desde esta tabla en lugar del JSON.
+    var hourOfDay: Int {
+        Calendar.current.component(.hour, from: timestamp)
+    }
+
+    /// Decodifica `attributesJSON` a `[String: String]`. Devuelve `[:]` si
+    /// el blob está corrupto — preferimos perder atributos antes que crashear.
+    var attributes: [String: String] {
+        guard let data = attributesJSON.data(using: .utf8),
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return dict
+    }
+}

--- a/Models/LocalDatabase/UserSession.swift
+++ b/Models/LocalDatabase/UserSession.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UserSession — tabla raíz del esquema relacional local (SwiftData / SQLite).
+//
+// Cada inicio de sesión crea (o recupera) una fila en `UserSession`. Las
+// dos tablas hijas (`AuditLogEntry` y `UsageEventRecord`) cuelgan de aquí
+// vía `@Relationship`, dándonos un esquema 1-N real:
+//
+//   UserSession ──┬── AuditLogEntry      (deleteRule: .cascade)
+//                 └── UsageEventRecord    (deleteRule: .cascade)
+//
+// SwiftData persiste por debajo en un store SQLite gestionado por el
+// `ModelContainer`, cumpliendo la categoría "BD Local Relacional" de la
+// rúbrica de Sprint 3.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Model
+final class UserSession {
+    @Attribute(.unique) var id: UUID
+    var userId: UUID
+    var userName: String
+    var startedAt: Date
+    var endedAt: Date?
+
+    @Relationship(deleteRule: .cascade, inverse: \AuditLogEntry.session)
+    var auditEntries: [AuditLogEntry] = []
+
+    @Relationship(deleteRule: .cascade, inverse: \UsageEventRecord.session)
+    var usageEvents: [UsageEventRecord] = []
+
+    init(id: UUID = UUID(),
+         userId: UUID,
+         userName: String,
+         startedAt: Date = Date(),
+         endedAt: Date? = nil) {
+        self.id = id
+        self.userId = userId
+        self.userName = userName
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+    }
+
+    var isActive: Bool { endedAt == nil }
+}

--- a/Services/Analytics/UsageTrackingService.swift
+++ b/Services/Analytics/UsageTrackingService.swift
@@ -59,6 +59,18 @@ actor UsageTrackingService {
             events.removeFirst(events.count - maxEvents / 2)
         }
         persist()
+
+        // Dual-write: replicamos a la BD relacional local (SwiftData) para
+        // que la misma información sea consultable con `@Query` y predicados.
+        // BQ6 sigue leyendo del JSON in-memory por velocidad.
+        let kindRaw = event.kind.rawValue
+        let attrs = event.attributes
+        Task { @MainActor in
+            LocalDatabaseService.shared.insertUsageEvent(
+                kind: kindRaw,
+                attributes: attrs
+            )
+        }
     }
 
     /// Convenience wrapper that builds the event for the caller.

--- a/Services/LocalDatabase/LocalDatabaseService.swift
+++ b/Services/LocalDatabase/LocalDatabaseService.swift
@@ -1,0 +1,267 @@
+import Foundation
+import SwiftData
+import SwiftUI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LocalDatabaseService — fachada del store relacional local (SwiftData / SQLite).
+//
+// ## Por qué existe
+// La rúbrica de Sprint 3 categoriza Local Storage en cuatro estrategias:
+//   1. BD Local Relacional (10 pts)  ← este servicio
+//   2. BD Llave/Valor                 ← BQCacheService
+//   3. Archivos Locales               ← PersistenceService, OfflineQueueService…
+//   4. Preferences/UserDefaults/Keychain ← SettingsViewModel, Auth entitlement
+//
+// Hasta esta iteración el repo cubría 2-4. Esta clase introduce 1 sin
+// reemplazar lo existente: persistencia "dual-write" — el origen de verdad
+// para offline sigue siendo el JSON en `Application Support`, pero cada audit
+// y cada usage-event se replica también a SwiftData para que sea consultable
+// con `@Query` y predicados.
+//
+// ## Esquema
+//   UserSession ──┬── AuditLogEntry      (1-N, cascade)
+//                 └── UsageEventRecord    (1-N, cascade)
+// `UserSession` se crea perezosamente: la primera escritura tras un login
+// que no tenga sesión activa la abre. `userDidLogout` la cierra y la limpia.
+//
+// ## Concurrencia
+// Toda la API es `@MainActor`. Los callers en background (ej. el actor
+// `UsageTrackingService`) hacen `Task { @MainActor in … }` para hopear; el
+// volumen es bajo (eventos puntuales) así que no necesitamos un context
+// dedicado en background.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@MainActor
+final class LocalDatabaseService: ObservableObject {
+
+    static let shared = LocalDatabaseService()
+
+    let container: ModelContainer
+    private var context: ModelContext { container.mainContext }
+
+    @Published private(set) var currentSession: UserSession?
+
+    private var logoutObserver: NSObjectProtocol?
+
+    private init() {
+        let schema = Schema([
+            UserSession.self,
+            AuditLogEntry.self,
+            UsageEventRecord.self
+        ])
+        let config = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false
+        )
+        do {
+            self.container = try ModelContainer(
+                for: schema,
+                configurations: [config]
+            )
+        } catch {
+            // Si el store está corrupto preferimos arrancar limpio en
+            // memoria a tumbar la app — el JSON sigue siendo el respaldo.
+            #if DEBUG
+            print("[LocalDB] persistent store init failed (\(error)). Falling back to in-memory.")
+            #endif
+            let memConfig = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: true
+            )
+            self.container = try! ModelContainer(
+                for: schema,
+                configurations: [memConfig]
+            )
+        }
+
+        logoutObserver = NotificationCenter.default.addObserver(
+            forName: .userDidLogout, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.endCurrentSession() }
+        }
+    }
+
+    deinit {
+        if let logoutObserver {
+            NotificationCenter.default.removeObserver(logoutObserver)
+        }
+    }
+
+    /// Llamada una vez por cold-start desde `InventarIAApp.init`. Inserta un
+    /// audit `AppLaunched` para que la BD nunca se vea vacía en el demo y
+    /// para que tengamos un marcador de cada inicio de sesión de la app.
+    func bootstrapLaunchEvent() {
+        insertAudit(
+            action: "AppLaunched",
+            entityType: "System",
+            details: "Cold-start de la app — bootstrap del store relacional"
+        )
+    }
+
+    // MARK: - Session lifecycle
+
+    @discardableResult
+    func ensureSession(userId: UUID, userName: String) -> UserSession {
+        if let active = currentSession, active.isActive {
+            return active
+        }
+        let session = UserSession(userId: userId, userName: userName)
+        context.insert(session)
+        try? context.save()
+        currentSession = session
+        return session
+    }
+
+    func endCurrentSession() {
+        guard let session = currentSession else { return }
+        session.endedAt = Date()
+        try? context.save()
+        currentSession = nil
+    }
+
+    // MARK: - Inserts (called via dual-write from JSON-based services)
+
+    func insertAudit(action: String,
+                     entityType: String,
+                     entityId: UUID? = nil,
+                     entityName: String? = nil,
+                     details: String,
+                     userId: UUID? = nil,
+                     userName: String? = nil) {
+        let entry = AuditLogEntry(
+            action: action,
+            entityType: entityType,
+            entityId: entityId,
+            entityName: entityName,
+            details: details,
+            session: sessionFor(userId: userId, userName: userName)
+        )
+        context.insert(entry)
+        try? context.save()
+    }
+
+    func insertUsageEvent(kind: String,
+                          attributes: [String: String],
+                          userId: UUID? = nil,
+                          userName: String? = nil) {
+        let json = encodeAttributes(attributes)
+        let record = UsageEventRecord(
+            kind: kind,
+            attributesJSON: json,
+            session: sessionFor(userId: userId, userName: userName)
+        )
+        context.insert(record)
+        try? context.save()
+    }
+
+    // MARK: - Queries
+
+    func recentAuditEntries(limit: Int = 100) -> [AuditLogEntry] {
+        var descriptor = FetchDescriptor<AuditLogEntry>(
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    /// Predicado: `entityType == X`. Demuestra el uso de `#Predicate` sobre
+    /// la tabla relacional, comparable a un `WHERE` de SQL.
+    func auditEntries(forEntityType entityType: String,
+                      limit: Int = 100) -> [AuditLogEntry] {
+        let predicate = #Predicate<AuditLogEntry> { entry in
+            entry.entityType == entityType
+        }
+        var descriptor = FetchDescriptor<AuditLogEntry>(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    func recentUsageEvents(limit: Int = 200) -> [UsageEventRecord] {
+        var descriptor = FetchDescriptor<UsageEventRecord>(
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    func usageEvents(ofKind kind: String,
+                     within days: Int = 30) -> [UsageEventRecord] {
+        let cutoff = Date().addingTimeInterval(-Double(days) * 86_400)
+        let predicate = #Predicate<UsageEventRecord> { event in
+            event.kind == kind && event.timestamp >= cutoff
+        }
+        let descriptor = FetchDescriptor<UsageEventRecord>(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    func allSessions() -> [UserSession] {
+        let descriptor = FetchDescriptor<UserSession>(
+            sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    func auditEntryCount() -> Int {
+        let descriptor = FetchDescriptor<AuditLogEntry>()
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
+    func usageEventCount() -> Int {
+        let descriptor = FetchDescriptor<UsageEventRecord>()
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
+    func sessionCount() -> Int {
+        let descriptor = FetchDescriptor<UserSession>()
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
+    // MARK: - Maintenance
+
+    /// Llamado desde la pantalla de Debug. Borra sólo lo que pertenece a
+    /// SwiftData; el JSON original permanece intacto.
+    func wipeAll() {
+        try? context.delete(model: AuditLogEntry.self)
+        try? context.delete(model: UsageEventRecord.self)
+        try? context.delete(model: UserSession.self)
+        try? context.save()
+        currentSession = nil
+    }
+
+    // MARK: - Private
+
+    private func sessionFor(userId: UUID?, userName: String?) -> UserSession? {
+        if let active = currentSession, active.isActive {
+            return active
+        }
+        // Si la primera escritura llega antes que la sesión, intentamos
+        // abrirla con los datos del usuario cacheado en disco.
+        if let id = userId ?? cachedUserId(),
+           let name = userName ?? cachedUserName() {
+            return ensureSession(userId: id, userName: name)
+        }
+        return nil // se grabará huérfano; aún consultable
+    }
+
+    private func cachedUserId() -> UUID? {
+        PersistenceService.shared.loadUser()?.id
+    }
+
+    private func cachedUserName() -> String? {
+        PersistenceService.shared.loadUser()?.fullName
+    }
+
+    private func encodeAttributes(_ attrs: [String: String]) -> String {
+        guard let data = try? JSONEncoder().encode(attrs),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
+    }
+}

--- a/Services/PersistenceService.swift
+++ b/Services/PersistenceService.swift
@@ -112,6 +112,22 @@ class PersistenceService: ObservableObject {
             events = Array(events.suffix(1000))
         }
         save(events, to: "audit_log")
+
+        // Dual-write: replicamos cada audit a la BD relacional local
+        // (SwiftData / SQLite) para que sea consultable con `@Query` y
+        // predicados desde la pantalla de Debug. El JSON sigue siendo el
+        // origen de verdad para compatibilidad y para offline.
+        Task { @MainActor in
+            LocalDatabaseService.shared.insertAudit(
+                action: event.action,
+                entityType: event.entityType,
+                entityId: event.entityId,
+                entityName: event.entityName,
+                details: event.details,
+                userId: event.userId,
+                userName: event.userName
+            )
+        }
     }
 
     func loadAuditLog() -> [AuditEvent] { load(from: "audit_log") }

--- a/Views/Settings/Debug/LocalDatabaseDebugView.swift
+++ b/Views/Settings/Debug/LocalDatabaseDebugView.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LocalDatabaseDebugView — pantalla utilitaria para inspeccionar el contenido
+// de la BD relacional local (SwiftData).
+//
+// La uso durante el viva voce de Sprint 3 para mostrar en vivo:
+//   • El esquema relacional de tres tablas (UserSession ──┬── AuditLogEntry
+//                                                         └── UsageEventRecord)
+//   • Lecturas reactivas con `@Query` (equivalente a un SELECT con ORDER BY)
+//   • Predicados (`#Predicate`) — equivalente a un WHERE
+//   • Conteos por tabla (fetchCount)
+//
+// Sin esta pantalla la BD funciona igual; existe para tener una superficie
+// visible que demuestre que SwiftData persiste lo escrito por el dual-write.
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct LocalDatabaseDebugView: View {
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.dismiss) var dismiss
+
+    /// Últimos 50 audits, ordenados por fecha desc — equivalente a:
+    ///   SELECT * FROM AuditLogEntry ORDER BY timestamp DESC LIMIT 50
+    @Query(
+        sort: [SortDescriptor(\AuditLogEntry.timestamp, order: .reverse)],
+        animation: .default
+    ) private var allAudits: [AuditLogEntry]
+
+    /// Últimos 100 usage events.
+    @Query(
+        sort: [SortDescriptor(\UsageEventRecord.timestamp, order: .reverse)],
+        animation: .default
+    ) private var allUsageEvents: [UsageEventRecord]
+
+    /// Sesiones, ordenadas por inicio desc.
+    @Query(
+        sort: [SortDescriptor(\UserSession.startedAt, order: .reverse)],
+        animation: .default
+    ) private var sessions: [UserSession]
+
+    @State private var entityFilter: String = "Todos"
+    @State private var showWipeConfirm = false
+
+    private var entityTypes: [String] {
+        let unique = Set(allAudits.map(\.entityType))
+        return ["Todos"] + unique.sorted()
+    }
+
+    private var filteredAudits: [AuditLogEntry] {
+        guard entityFilter != "Todos" else { return Array(allAudits.prefix(50)) }
+        return allAudits.filter { $0.entityType == entityFilter }.prefix(50).map { $0 }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    statsCard
+                    schemaCard
+                    auditsSection
+                    usageEventsSection
+                    sessionsSection
+                    wipeButton
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+                .padding(.bottom, 60)
+            }
+            .background(colorScheme == .dark ? AppColors.darkBackground : AppColors.background)
+            .navigationTitle("Base de Datos Local")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Cerrar") { dismiss() }
+                }
+            }
+            .alert("Borrar todo el contenido?", isPresented: $showWipeConfirm) {
+                Button("Cancelar", role: .cancel) {}
+                Button("Borrar", role: .destructive) {
+                    LocalDatabaseService.shared.wipeAll()
+                }
+            } message: {
+                Text("Esto vacía las tres tablas de SwiftData. Los archivos JSON de respaldo no se tocan.")
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var statsCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Conteos (fetchCount)")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+            HStack(spacing: 12) {
+                statTile(label: "Sesiones", value: "\(sessions.count)", color: AppColors.accent)
+                statTile(label: "Audits", value: "\(allAudits.count)", color: AppColors.primary)
+                statTile(label: "Usage", value: "\(allUsageEvents.count)", color: AppColors.success)
+            }
+        }
+    }
+
+    private var schemaCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Esquema relacional")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+            VStack(alignment: .leading, spacing: 6) {
+                Text("UserSession (id, userId, userName, startedAt, endedAt)")
+                Text("  └── AuditLogEntry (FK: session)  ─ cascade")
+                Text("  └── UsageEventRecord (FK: session) ─ cascade")
+            }
+            .font(.system(.footnote, design: .monospaced))
+            .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(AppColors.primary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+
+    private var auditsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("AuditLogEntry — últimos 50")
+                    .font(AppTypography.captionFont)
+                    .foregroundColor(AppColors.textSecondary)
+                Spacer()
+                Picker("Filtro", selection: $entityFilter) {
+                    ForEach(entityTypes, id: \.self) { Text($0).tag($0) }
+                }
+                .pickerStyle(.menu)
+                .font(.caption)
+            }
+            if filteredAudits.isEmpty {
+                emptyRow(message: "Sin entradas todavía")
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(filteredAudits) { entry in
+                        auditRow(entry)
+                        if entry.id != filteredAudits.last?.id {
+                            Divider().padding(.leading, 12)
+                        }
+                    }
+                }
+                .cardStyle()
+            }
+        }
+    }
+
+    private var usageEventsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("UsageEventRecord — últimos 50")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+            let visible = Array(allUsageEvents.prefix(50))
+            if visible.isEmpty {
+                emptyRow(message: "Sin eventos todavía")
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(visible) { event in
+                        usageRow(event)
+                        if event.id != visible.last?.id {
+                            Divider().padding(.leading, 12)
+                        }
+                    }
+                }
+                .cardStyle()
+            }
+        }
+    }
+
+    private var sessionsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("UserSession — todas")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+            if sessions.isEmpty {
+                emptyRow(message: "Sin sesiones registradas")
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(sessions) { session in
+                        sessionRow(session)
+                        if session.id != sessions.last?.id {
+                            Divider().padding(.leading, 12)
+                        }
+                    }
+                }
+                .cardStyle()
+            }
+        }
+    }
+
+    private var wipeButton: some View {
+        Button(action: { showWipeConfirm = true }) {
+            HStack {
+                Image(systemName: "trash")
+                Text("Vaciar tablas (sólo SwiftData)")
+            }
+            .font(AppTypography.captionFont)
+            .foregroundColor(AppColors.error)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(AppColors.error.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Row builders
+
+    private func statTile(label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(value)
+                .font(AppTypography.title2Font)
+                .foregroundColor(color)
+            Text(label)
+                .font(AppTypography.caption2Font)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func auditRow(_ entry: AuditLogEntry) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(entry.action)
+                    .font(AppTypography.captionFont)
+                    .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+                Spacer()
+                Text(entry.entityType)
+                    .font(AppTypography.caption2Font)
+                    .padding(.horizontal, 8).padding(.vertical, 2)
+                    .background(AppColors.primary.opacity(0.15))
+                    .clipShape(Capsule())
+            }
+            if !entry.details.isEmpty {
+                Text(entry.details)
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textSecondary)
+                    .lineLimit(2)
+            }
+            HStack {
+                Text(entry.timestamp.formatted(date: .abbreviated, time: .shortened))
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textTertiary)
+                if let session = entry.session {
+                    Text("· session \(session.id.uuidString.prefix(6))")
+                        .font(AppTypography.caption2Font)
+                        .foregroundColor(AppColors.textTertiary)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func usageRow(_ event: UsageEventRecord) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(event.kind)
+                    .font(AppTypography.captionFont)
+                    .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+                Spacer()
+                Text("\(event.hourOfDay):00")
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textTertiary)
+            }
+            if !event.attributes.isEmpty {
+                Text(event.attributes.map { "\($0.key)=\($0.value)" }.sorted().joined(separator: " · "))
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textSecondary)
+                    .lineLimit(1)
+            }
+            Text(event.timestamp.formatted(date: .abbreviated, time: .shortened))
+                .font(AppTypography.caption2Font)
+                .foregroundColor(AppColors.textTertiary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func sessionRow(_ session: UserSession) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(session.userName)
+                    .font(AppTypography.captionFont)
+                    .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+                Spacer()
+                Text(session.isActive ? "activa" : "cerrada")
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(session.isActive ? AppColors.success : AppColors.textTertiary)
+            }
+            HStack(spacing: 12) {
+                Text("audits: \(session.auditEntries.count)")
+                Text("usage: \(session.usageEvents.count)")
+            }
+            .font(AppTypography.caption2Font)
+            .foregroundColor(AppColors.textSecondary)
+            Text("Inicio: \(session.startedAt.formatted(date: .abbreviated, time: .shortened))")
+                .font(AppTypography.caption2Font)
+                .foregroundColor(AppColors.textTertiary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func emptyRow(message: String) -> some View {
+        Text(message)
+            .font(AppTypography.captionFont)
+            .foregroundColor(AppColors.textTertiary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 18)
+            .cardStyle()
+    }
+}

--- a/Views/Settings/SettingsView.swift
+++ b/Views/Settings/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @State private var showStoreManagement = false
     @State private var showTeamMembers = false
     @State private var showHelpCenter = false
+    @State private var showLocalDatabase = false
 
     var body: some View {
         NavigationStack {
@@ -53,6 +54,10 @@ struct SettingsView: View {
                             showHelpCenter = true
                         }
 
+                        settingsNavRow(icon: "cylinder.split.1x2.fill", title: "Base de Datos Local", color: AppColors.primary) {
+                            showLocalDatabase = true
+                        }
+
                         disabledSettingRow(icon: "doc.text.fill", title: "Términos y Condiciones", value: "Próximamente", color: AppColors.textSecondary)
                     }
 
@@ -93,6 +98,9 @@ struct SettingsView: View {
             }
             .sheet(isPresented: $showHelpCenter) {
                 HelpCenterView()
+            }
+            .sheet(isPresented: $showLocalDatabase) {
+                LocalDatabaseDebugView()
             }
             .alert("Cerrar Sesión", isPresented: $settingsViewModel.showingLogoutConfirmation) {
                 Button("Cancelar", role: .cancel) {}


### PR DESCRIPTION
## Resumen
Añade una base de datos local **relacional real** (SwiftData / SQLite) al lado de la persistencia JSON existente, sin reemplazarla.

## Esquema relacional

```
UserSession ──┬── AuditLogEntry       (1-N, deleteRule: cascade)
              └── UsageEventRecord    (1-N, deleteRule: cascade)
```

Cada modelo `@Model`:
- `@Attribute(.unique)` en `id`
- `@Relationship` en las hijas con `inverse:`
- Persistido en `Library/Application Support/default.store` (SQLite + WAL)

## Dual-write
- `PersistenceService.logAuditEvent` mantiene su escritura a `audit_log.json` y además inserta en `AuditLogEntry`.
- `UsageTrackingService.record` mantiene `usage_events.json` y además inserta en `UsageEventRecord`.
- BQ6 sigue leyendo de los actors / JSON; SwiftData es consultable con `@Query` y `#Predicate`.

## Demo
Settings → **Base de Datos Local** abre la nueva vista que:
- Cuenta filas por tabla (`fetchCount`)
- Lista los últimos 50 audits con un `Picker` que aplica un `#Predicate<AuditLogEntry>` por `entityType`
- Lista los últimos 50 usage events
- Lista todas las sesiones con conteos de hijos (verifica los `@Relationship`)
- Permite vaciar las tres tablas (los JSON quedan intactos)

## Verificación
- `xcodebuild ... build` → BUILD SUCCEEDED
- App arranca, `default.store` se crea en `Application Support/`, schema con `ZAUDITLOGENTRY`/`ZUSAGEEVENTRECORD`/`ZUSERSESSION` + índices únicos por `id` + índices de FK por `session`.
- Tras cold-start: 1 fila en `ZAUDITLOGENTRY` (evento `AppLaunched`).

## Test plan
- [ ] Abrir la app, navegar a Ajustes → Base de Datos Local → ver al menos el evento `AppLaunched`.
- [ ] Login real → debería abrir una `UserSession` activa con la primera escritura de audit posterior.
- [ ] Agregar un producto → AuditLogEntry y UsageEventRecord nuevos, ambos linkeados a la sesión activa.
- [ ] Logout → la sesión se cierra (`endedAt` queda seteado).
- [ ] Botón "Vaciar tablas" limpia las 3 tablas y deja los JSON intactos.