### PR TITLE
feat(angel): fill strategy gaps in Angel's domain (re-submit to main)

### DIFF
--- a/Services/Repositories/OpenFoodFactsRepository.swift
+++ b/Services/Repositories/OpenFoodFactsRepository.swift
@@ -13,6 +13,29 @@ final class OpenFoodFactsRepository: OpenFoodFactsRepositoryProtocol {
     private let networkMonitor = NetworkMonitor.shared
     private let session: URLSession
 
+    // FIX: Caching — NSCache con countLimit y totalCostLimit explícitos.
+    //
+    // El usuario escanea el mismo barcode varias veces (por error, por
+    // demo, por edición del mismo producto). Sin caché, cada scan dispara
+    // un round-trip de ~200ms a Open Food Facts. Con NSCache:
+    //   • countLimit: 128 productos — cubre un día de scans en una tienda
+    //   • totalCostLimit: 2 MB — los DTOs son chicos (~1-3 KB cada uno),
+    //                            esto deja margen para imágenes embebidas
+    //   • NSCache responde a memory warnings del OS automáticamente
+    //   • thread-safe nativo, no necesitamos serializar manualmente
+    private let lookupCache: NSCache<NSString, CachedOFFProduct> = {
+        let cache = NSCache<NSString, CachedOFFProduct>()
+        cache.countLimit = 128
+        cache.totalCostLimit = 2 * 1024 * 1024
+        cache.name = "openFoodFacts.lookup"
+        return cache
+    }()
+
+    /// TTL: el catálogo de Open Food Facts es estable — un producto
+    /// reportado hoy tiene los mismos datos mañana. 24 h de caché es
+    /// razonable y permite trabajo offline contra barcodes vistos.
+    private let cacheTTL: TimeInterval = 24 * 60 * 60
+
     init(session: URLSession = .shared) {
         self.session = session
     }
@@ -26,16 +49,25 @@ final class OpenFoodFactsRepository: OpenFoodFactsRepositoryProtocol {
     ///           `APIError.serverError` on non-2xx status codes,
     ///           `APIError.decodingError` on malformed responses.
     func lookup(barcode: String) async throws -> OpenFoodFactsProduct? {
-        guard networkMonitor.isConnected else {
-            throw APIError.offline
-        }
-
         // Validación: solo dígitos, máx 32 chars (previene URL injection)
         let trimmed = barcode.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
               trimmed.count <= 32,
               trimmed.allSatisfy({ $0.isNumber }) else {
             throw APIError.invalidURL
+        }
+
+        // FIX: Caching — chequeo de caché ANTES del network. Esto cubre el
+        // modo offline si ya vimos el barcode antes (TTL 24h), y elimina
+        // ~200ms de latencia + un round-trip por scan repetido.
+        let key = trimmed as NSString
+        if let cached = lookupCache.object(forKey: key),
+           Date().timeIntervalSince(cached.cachedAt) < cacheTTL {
+            return cached.product
+        }
+
+        guard networkMonitor.isConnected else {
+            throw APIError.offline
         }
 
         // Construir URL de forma segura (sin string interpolation directa)
@@ -81,9 +113,28 @@ final class OpenFoodFactsRepository: OpenFoodFactsRepositoryProtocol {
             guard decoded.status == 1, let productDTO = decoded.product else {
                 return nil
             }
-            return productDTO.toDomain(barcode: trimmed)
+            let product = productDTO.toDomain(barcode: trimmed)
+
+            // FIX: Caching — guardamos en NSCache con cost = tamaño del JSON
+            // crudo. Eso permite que `totalCostLimit` haga eviction inteligente
+            // basada en memoria real ocupada, no sólo en número de entradas.
+            let boxed = CachedOFFProduct(product: product, cachedAt: Date())
+            lookupCache.setObject(boxed, forKey: key, cost: data.count)
+
+            return product
         } catch {
             throw APIError.decodingError(error)
         }
+    }
+}
+
+/// Wrapper de referencia para `NSCache`, que sólo acepta `AnyObject`. Lleva
+/// `cachedAt` para que el caller pueda decidir TTL sin re-pegar al disco.
+private final class CachedOFFProduct {
+    let product: OpenFoodFactsProduct
+    let cachedAt: Date
+    init(product: OpenFoodFactsProduct, cachedAt: Date) {
+        self.product = product
+        self.cachedAt = cachedAt
     }
 }

--- a/Services/Restock/RestockCycleStore.swift
+++ b/Services/Restock/RestockCycleStore.swift
@@ -13,9 +13,24 @@ actor RestockCycleStore {
     private let decoder: JSONDecoder
     private let fileManager = FileManager.default
 
+    // FIX: Multithreading (AsyncSequence) — stream de ciclos a medida que
+    // se registran. Permite a `InventoryInsightsViewModel` reaccionar con
+    // `for await cycle in RestockCycleStore.shared.cycleEvents` y
+    // refrescar la BQ3 sin tener que hacer polling.
+    //
+    // `nonisolated` para que SwiftUI consumers puedan acceder sin hopear
+    // dentro del actor — la `Continuation` es thread-safe por sí misma.
+    nonisolated let cycleEvents: AsyncStream<RestockCycle>
+    private nonisolated let cycleEventsContinuation: AsyncStream<RestockCycle>.Continuation
+
     private init() {
         encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
         decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+
+        // FIX: AsyncStream construction with continuation pattern
+        var cont: AsyncStream<RestockCycle>.Continuation!
+        self.cycleEvents = AsyncStream { c in cont = c }
+        self.cycleEventsContinuation = cont
     }
 
     // MARK: - Public API
@@ -25,6 +40,9 @@ actor RestockCycleStore {
         cycles.append(cycle)
         if cycles.count > cap { cycles.removeFirst(cycles.count - cap / 2) }
         persist()
+        // FIX: AsyncSequence — emite el evento al stream para que cualquier
+        // observador (BQ3 ViewModel, dashboards) reaccione en tiempo real.
+        cycleEventsContinuation.yield(cycle)
     }
 
     func allCycles() -> [RestockCycle] {
@@ -45,29 +63,48 @@ actor RestockCycleStore {
     }
 
 
-    func backfillIfEmpty(from products: [Product]) {
+    func backfillIfEmpty(from products: [Product]) async {
         loadIfNeeded()
         guard cycles.isEmpty, !products.isEmpty else { return }
 
-        var rng = SystemRandomNumberGenerator()
-        let now = Date()
-        var generated: [RestockCycle] = []
+        // FIX: Multithreading (GCD) — el backfill genera 2-4 ciclos por
+        // producto y, con catálogos grandes, fácilmente entra en ~500
+        // entradas. Ejecutamos la generación en `DispatchQueue.global(qos: .utility)`
+        // para no bloquear el caller (que viene de @MainActor en
+        // `InventoryInsightsViewModel.refresh`).
+        //
+        // Diferencia explícita con Task.detached:
+        //   • Task.detached usa el cooperative thread pool de Swift.
+        //   • DispatchQueue.global(qos:) es GCD puro, el sistema de
+        //     concurrencia clásico de iOS — todavía vigente y necesario
+        //     cuando interoperamos con APIs de Foundation que prefieren
+        //     callbacks. Aquí lo usamos para demostrar la integración
+        //     entre concurrency moderna (await) y GCD legacy.
+        let generated: [RestockCycle] = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                var rng = SystemRandomNumberGenerator()
+                let now = Date()
+                var result: [RestockCycle] = []
+                result.reserveCapacity(products.count * 3)
 
-        for product in products where product.isActive {
-            let cycleCount = Int.random(in: 2...4, using: &rng)
-            var cursor = now.addingTimeInterval(-60 * 86_400) // 60 días atrás
-            for _ in 0..<cycleCount {
-                let gap = Double.random(in: 2...12, using: &rng) * 86_400
-                let duration = Double.random(in: 1.5...7, using: &rng) * 86_400
-                let outAt = cursor
-                let inAt = outAt.addingTimeInterval(duration)
-                generated.append(RestockCycle(
-                    productId: product.id,
-                    productName: product.name,
-                    outOfStockAt: outAt,
-                    restockedAt: inAt
-                ))
-                cursor = inAt.addingTimeInterval(gap)
+                for product in products where product.isActive {
+                    let cycleCount = Int.random(in: 2...4, using: &rng)
+                    var cursor = now.addingTimeInterval(-60 * 86_400)
+                    for _ in 0..<cycleCount {
+                        let gap = Double.random(in: 2...12, using: &rng) * 86_400
+                        let duration = Double.random(in: 1.5...7, using: &rng) * 86_400
+                        let outAt = cursor
+                        let inAt = outAt.addingTimeInterval(duration)
+                        result.append(RestockCycle(
+                            productId: product.id,
+                            productName: product.name,
+                            outOfStockAt: outAt,
+                            restockedAt: inAt
+                        ))
+                        cursor = inAt.addingTimeInterval(gap)
+                    }
+                }
+                continuation.resume(returning: result)
             }
         }
 

--- a/ViewModels/BQ/InventoryInsightsViewModel.swift
+++ b/ViewModels/BQ/InventoryInsightsViewModel.swift
@@ -20,21 +20,68 @@ final class InventoryInsightsViewModel: ObservableObject {
     private let cycleAnalyzer = RestockCycleAnalyzer.shared
     private let expirationAnalyzer = ExpirationInsightsAnalyzer.shared
 
-    // Tiny TTL cache to avoid recomputing while the user toggles around.
-    private struct CacheEntry<T> {
-        let value: T
-        let at: Date
+    // FIX: Caching — caché en `NSCache` con `countLimit` y `totalCostLimit`
+    // explícitos en vez de un dictionary manual con TTL ad-hoc. Beneficios:
+    //   • Eviction automática bajo memory warnings del OS
+    //   • Thread-safe nativo (no necesitamos coordinar mutaciones)
+    //   • `countLimit: 4` cubre las 2 BQ dashboards × 2 variantes (force/no-force)
+    //     sin desperdiciar memoria
+    //   • `totalCostLimit: 4 MB` blinda contra dashboards muy grandes
+    private let dashboardCache: NSCache<NSString, AnyObject> = {
+        let cache = NSCache<NSString, AnyObject>()
+        cache.countLimit = 4
+        cache.totalCostLimit = 4 * 1024 * 1024
+        cache.name = "inventoryInsights.dashboards"
+        return cache
+    }()
+
+    // FIX: Caching — wrappers de referencia para guardar structs (Sendable
+    // pero value-type) en NSCache, que requiere `AnyObject`.
+    private final class CachedRestock: AnyObject {
+        let value: RestockCyclesDashboard
+        let cachedAt: Date
+        init(_ v: RestockCyclesDashboard) { self.value = v; self.cachedAt = Date() }
     }
-    private var restockCache: CacheEntry<RestockCyclesDashboard>?
-    private var expirationCache: CacheEntry<ExpirationInsightsDashboard>?
+    private final class CachedExpiration: AnyObject {
+        let value: ExpirationInsightsDashboard
+        let cachedAt: Date
+        init(_ v: ExpirationInsightsDashboard) { self.value = v; self.cachedAt = Date() }
+    }
+    private static let restockKey: NSString = "restockDashboard"
+    private static let expirationKey: NSString = "expirationDashboard"
     private let ttl: TimeInterval = 5 * 60
 
     private var cancellables: Set<AnyCancellable> = []
+    private var cycleStreamTask: Task<Void, Never>?
 
     init() {
         NotificationCenter.default.publisher(for: .inventoryDidChange)
             .sink { [weak self] _ in self?.invalidateCache() }
             .store(in: &cancellables)
+
+        // FIX: Multithreading (AsyncSequence) — observamos el stream del
+        // `RestockCycleStore`. Cada vez que se registra un ciclo nuevo (por
+        // ejemplo, cuando `InventoryViewModel.logRestockIfNeeded` graba uno),
+        // invalidamos el caché de BQ3 para que la próxima lectura sea fresh.
+        // Esto reemplaza el patrón "poll cada N segundos" por reactividad
+        // real basada en eventos.
+        cycleStreamTask = Task { [weak self] in
+            guard let stream = await Self.cycleStreamHandle() else { return }
+            for await _ in stream {
+                await MainActor.run {
+                    self?.dashboardCache.removeObject(forKey: Self.restockKey)
+                }
+            }
+        }
+    }
+
+    deinit {
+        cycleStreamTask?.cancel()
+    }
+
+    // FIX: AsyncSequence — helper para acceder al stream nonisolated del actor.
+    private static func cycleStreamHandle() async -> AsyncStream<RestockCycle>? {
+        RestockCycleStore.shared.cycleEvents
     }
 
     /// Re-computes BQ3 and BQ4 in parallel.
@@ -49,10 +96,13 @@ final class InventoryInsightsViewModel: ObservableObject {
     }
 
     func refreshRestock(products: [Product], forceFresh: Bool) async {
+        // FIX: Caching — lookup en NSCache con check de TTL. NSCache
+        // descarta entradas bajo presión de memoria, no necesitamos
+        // limpiar manualmente.
         if !forceFresh,
-           let hit = restockCache,
-           Date().timeIntervalSince(hit.at) < ttl {
-            restockDashboard = hit.value
+           let cached = dashboardCache.object(forKey: Self.restockKey) as? CachedRestock,
+           Date().timeIntervalSince(cached.cachedAt) < ttl {
+            restockDashboard = cached.value
             return
         }
         isLoadingRestock = true
@@ -60,21 +110,26 @@ final class InventoryInsightsViewModel: ObservableObject {
         let cycles = await cycleStore.cycles(within: 90)
         let result = await cycleAnalyzer.compute(products: products, cycles: cycles)
         restockDashboard = result
-        restockCache = CacheEntry(value: result, at: Date())
+        // FIX: Caching — guardamos con cost aproximado (32B por ProductRestockStats).
+        dashboardCache.setObject(CachedRestock(result),
+                                 forKey: Self.restockKey,
+                                 cost: max(1024, result.products.count * 32))
     }
 
     func refreshExpiration(products: [Product], forceFresh: Bool) async {
         if !forceFresh,
-           let hit = expirationCache,
-           Date().timeIntervalSince(hit.at) < ttl {
-            expirationDashboard = hit.value
+           let cached = dashboardCache.object(forKey: Self.expirationKey) as? CachedExpiration,
+           Date().timeIntervalSince(cached.cachedAt) < ttl {
+            expirationDashboard = cached.value
             return
         }
         isLoadingExpiration = true
         defer { isLoadingExpiration = false }
         let result = await expirationAnalyzer.compute(products: products)
         expirationDashboard = result
-        expirationCache = CacheEntry(value: result, at: Date())
+        dashboardCache.setObject(CachedExpiration(result),
+                                 forKey: Self.expirationKey,
+                                 cost: max(1024, result.totalAtRisk * 32))
     }
 
     func logRestockIfNeeded(previous: Product?, current: Product) async {
@@ -96,7 +151,6 @@ final class InventoryInsightsViewModel: ObservableObject {
     }
 
     private func invalidateCache() {
-        restockCache = nil
-        expirationCache = nil
+        dashboardCache.removeAllObjects()
     }
 }

--- a/ViewModels/InventoryViewModel.swift
+++ b/ViewModels/InventoryViewModel.swift
@@ -16,8 +16,29 @@ class InventoryViewModel: ObservableObject {
 
     // Search and Filter
     @Published var searchText = ""
-    @Published var selectedFilter: StockFilter = .all
-    @Published var selectedCategory: ProductCategory?
+    // FIX: Local Storage (UserDefaults) — persistimos el último filtro y
+    // categoría seleccionados para que el usuario no tenga que reconfigurar
+    // su vista cada vez que abre la app. Usamos `didSet` con un guard de
+    // `loadingPreferences` para evitar escrituras durante el restore.
+    @Published var selectedFilter: StockFilter = .all {
+        didSet {
+            guard !loadingPreferences else { return }
+            UserDefaults.standard.set(selectedFilter.rawValue, forKey: Self.inventoryFilterKey)
+        }
+    }
+    @Published var selectedCategory: ProductCategory? {
+        didSet {
+            guard !loadingPreferences else { return }
+            if let cat = selectedCategory {
+                UserDefaults.standard.set(cat.rawValue, forKey: Self.inventoryCategoryKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.inventoryCategoryKey)
+            }
+        }
+    }
+    private var loadingPreferences = false
+    private static let inventoryFilterKey = "inventory.selectedFilter"
+    private static let inventoryCategoryKey = "inventory.selectedCategory"
 
     // Product Form
     @Published var editingProduct: Product?
@@ -45,6 +66,20 @@ class InventoryViewModel: ObservableObject {
     }
 
     init() {
+        // FIX: Local Storage (UserDefaults) — restauramos preferencias del
+        // usuario ANTES de exponer cualquier @Published para evitar
+        // notificaciones espurias a SwiftUI.
+        loadingPreferences = true
+        if let raw = UserDefaults.standard.string(forKey: Self.inventoryFilterKey),
+           let filter = StockFilter(rawValue: raw) {
+            selectedFilter = filter
+        }
+        if let raw = UserDefaults.standard.string(forKey: Self.inventoryCategoryKey),
+           let cat = ProductCategory(rawValue: raw) {
+            selectedCategory = cat
+        }
+        loadingPreferences = false
+
         // Don't load data here — storeId may not be available yet.
         // Data is loaded when MainTabView appears (after login).
         logoutObserver = NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Por qué este PR existe
El PR #105 anterior fue mergeado por error a la rama \`fix/offline-edit-and-auth-errors\` en vez de a \`main\`. Como \`fix/offline-edit-and-auth-errors\` ya se cerró con #104, los cambios de Angel quedaron huérfanos. Este PR re-aplica el mismo commit (cherry-pick de \`4bfa6c5\`) directamente contra \`main\`.

## Cambios (idénticos a #105)

| Archivo | Estrategia agregada |
|---|---|
| \`Services/Repositories/OpenFoodFactsRepository.swift\` | Caching (NSCache con countLimit + totalCostLimit + TTL) |
| \`Services/Restock/RestockCycleStore.swift\` | Multithreading (GCD via DispatchQueue.global) + AsyncSequence |
| \`ViewModels/BQ/InventoryInsightsViewModel.swift\` | Caching (NSCache reemplaza TTL manual) + AsyncSequence consumer |
| \`ViewModels/InventoryViewModel.swift\` | Local Storage (UserDefaults con didSet para filter + category) |

Cada cambio sigue marcado con \`// FIX: <categoría>\` para trazabilidad en el viva voce.

## Verificación
- \`xcodebuild Debug\` → BUILD SUCCEEDED
- Diff vs main: solo los 4 archivos esperados, +220 / -43 líneas.

## Test plan
Mismo del PR #105:
- [ ] Filtro de inventario persiste entre cold-starts (UserDefaults)
- [ ] Escanear barcode dos veces → segundo lookup instantáneo (NSCache)
- [ ] \`backfillIfEmpty\` no congela el main thread (GCD background)
- [ ] Registrar ciclo de restock invalida BQ3 automáticamente (AsyncSequence)