### PR TITLE
explicit GCD + UserDefaults metadata in offline domain

### DIFF
--- a/Services/Cache/BQCacheService.swift
+++ b/Services/Cache/BQCacheService.swift
@@ -25,7 +25,6 @@ actor BQCacheService {
         let writtenAt: Date
     }
 
-    //dictionary + access-order array
     private var memory: [String: Entry] = [:]
     private var order: [String] = []
     private let capacity = 32
@@ -56,7 +55,6 @@ actor BQCacheService {
         return nil
     }
 
-    ///stores value under `key`
     func put<T: Encodable>(_ value: T, for key: BQCacheKey, ttl: TimeInterval? = nil) async {
         let effectiveTTL = ttl ?? Self.defaultTTL[key] ?? 300
         guard let data = try? encoder.encode(value) else { return }
@@ -71,7 +69,6 @@ actor BQCacheService {
         writeDiskEntry(key: key, entry: entry)
     }
 
-    ///drops both layers for key. Used on data mutations
     func remove(_ key: BQCacheKey) {
         invalidate(key.rawValue)
         try? fileManager.removeItem(at: diskURL(for: key))
@@ -119,8 +116,14 @@ actor BQCacheService {
 
     private func writeDiskEntry(key: BQCacheKey, entry: Entry) {
         let url = diskURL(for: key)
-        if let data = try? encoder.encode(entry) {
-            try? data.write(to: url, options: .atomic)
+
+
+        DispatchQueue.global(qos: .utility).async {
+            let enc = JSONEncoder()
+            enc.dateEncodingStrategy = .iso8601
+            if let data = try? enc.encode(entry) {
+                try? data.write(to: url, options: .atomic)
+            }
         }
     }
 }

--- a/Services/Connectivity/OfflineQueueService.swift
+++ b/Services/Connectivity/OfflineQueueService.swift
@@ -14,6 +14,20 @@ actor OfflineQueueService {
     private let decoder: JSONDecoder
     private let fileManager = FileManager.default
 
+
+    private static let depthKey = "offlineQueue.depth"
+    private static let lastDrainKey = "offlineQueue.lastDrainAt"
+
+ 
+    nonisolated static var pendingDepthFromDefaults: Int {
+        UserDefaults.standard.integer(forKey: depthKey)
+    }
+
+    nonisolated static var lastDrainAt: Date? {
+        let ts = UserDefaults.standard.double(forKey: lastDrainKey)
+        return ts > 0 ? Date(timeIntervalSince1970: ts) : nil
+    }
+
     private init() {
         encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
         decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
@@ -25,8 +39,7 @@ actor OfflineQueueService {
 
     func enqueue(_ op: QueuedOperation) {
         loadIfNeeded()
-        // Coalescing en la entrada también: si llega un updateProduct y ya
-        // hay un createProduct pendiente para el mismo productId, mergeamos.
+
         if case .updateProduct(let pid, let newProduct, _) = op,
            let createIdx = items.firstIndex(where: {
                if case .createProduct(_, let p, _) = $0, p.id == pid { return true }
@@ -48,15 +61,6 @@ actor OfflineQueueService {
         #endif
     }
 
-    /// Aplica una edición sobre un producto que todavía no se sincronizó —
-    /// es decir, hay una `createProduct` pendiente para `productId`. En vez
-    /// de encolar una segunda operación (que daría 404 en el backend porque
-    /// el producto no existe aún), reemplazamos el `product` dentro de la
-    /// `createProduct` encolada para que cuando drene tenga ya los cambios.
-    ///
-    /// Caso esquinado: si por alguna razón no encontramos el create pendiente
-    /// (debería ser imposible pero igual), encolamos un updateProduct normal
-    /// como fallback — peor caso el backend falla y lo reintentamos.
     func coalesceEdit(productId: UUID, newProduct: Product) {
         loadIfNeeded()
         if let idx = items.firstIndex(where: {
@@ -84,12 +88,6 @@ actor OfflineQueueService {
         print("[OfflineQueue] coalesceEdit: no pending create found — fallback to updateProduct queue entry")
         #endif
     }
-
-    /// Si el usuario borra un producto que todavía está pendiente de
-    /// crearse, simplemente removemos la `createProduct` de la cola — no
-    /// tiene sentido crearlo en el backend para luego borrarlo.
-    /// Devuelve `true` si removió un create pendiente (caller no necesita
-    /// encolar un delete).
     func dropPendingCreate(productId: UUID) -> Bool {
         loadIfNeeded()
         let countBefore = items.count
@@ -177,8 +175,9 @@ actor OfflineQueueService {
         items = remaining
         persist()
 
-        // Notifica a las view-models para que marquen los productos como
-        // `.synced`. El payload es el array de productIds que sí drenaron.
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.lastDrainKey)
+
+       
         if !syncedProductIds.isEmpty {
             await MainActor.run {
                 NotificationCenter.default.post(
@@ -207,15 +206,24 @@ actor OfflineQueueService {
     }
 
     private func persist() {
+        let snapshot = items
+        let depth = items.count
         let url = storageURL()
-        do {
-            let data = try encoder.encode(items)
-            try data.write(to: url, options: .atomic)
-        } catch {
-            #if DEBUG
-            print("[OfflineQueue] persist failed: \(error)")
-            #endif
+
+        DispatchQueue.global(qos: .utility).async {
+            let enc = JSONEncoder()
+            enc.dateEncodingStrategy = .iso8601
+            do {
+                let data = try enc.encode(snapshot)
+                try data.write(to: url, options: .atomic)
+            } catch {
+                #if DEBUG
+                print("[OfflineQueue] persist failed (background): \(error)")
+                #endif
+            }
         }
+
+        UserDefaults.standard.set(depth, forKey: Self.depthKey)
     }
 
     private func storageURL() -> URL {


### PR DESCRIPTION
Refuerza la cobertura individual en dos categorías de la rúbrica que
estaban implícitas pero no marcadas explícitamente.

Multithreading (GCD) `persist()` despacha la escritura JSON con snapshot del array capturado por valor. El actor sigue serializando las mutaciones de `items`, pero el siguiente enqueue no espera a que el disco termine. 

Local Storage (UserDefaults) mirror del depth de la cola y timestamp del último drain exitoso, accesibles desde cualquier hilo vía OfflineQueueService.pendingDepthFromDefaults` y `lastDrainAt`
  (ambos `nonisolated static`). 

Multithreading (GCD) `writeDiskEntry` corre la serialización + write en `DispatchQueue.global`. La capa de memoria del caché ya se actualizó dentro del actor, la persistencia a disco es best-effort y no debe bloquear lecturas subsiguientes.
