### PR TITLE
SwiftData entities + LocalKeyValueStore (BD relacional + KV)

### DIFF
--- a/Models/LocalDatabase/AnalyticsEventSample.swift
+++ b/Models/LocalDatabase/AnalyticsEventSample.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+@Model
+final class AnalyticsEventSample {
+    @Attribute(.unique) var id: UUID
+    var kind: String           // raw value of AnalyticsEvent.Kind
+    var timestamp: Date
+    var attributesJSON: String // [String: String] serialized
+
+    init(id: UUID = UUID(),
+         kind: String,
+         timestamp: Date = Date(),
+         attributesJSON: String = "{}") {
+        self.id = id
+        self.kind = kind
+        self.timestamp = timestamp
+        self.attributesJSON = attributesJSON
+    }
+
+    var attributes: [String: String] {
+        guard let data = attributesJSON.data(using: .utf8),
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return dict
+    }
+
+    var hourOfDay: Int {
+        Calendar.current.component(.hour, from: timestamp)
+    }
+}

--- a/Models/LocalDatabase/LocalKeyValueEntry.swift
+++ b/Models/LocalDatabase/LocalKeyValueEntry.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+
+@Model
+final class LocalKeyValueEntry {
+    @Attribute(.unique) var key: String
+    var value: Data
+    var expiresAt: Date?
+    var updatedAt: Date
+
+    init(key: String,
+         value: Data,
+         expiresAt: Date? = nil,
+         updatedAt: Date = Date()) {
+        self.key = key
+        self.value = value
+        self.expiresAt = expiresAt
+        self.updatedAt = updatedAt
+    }
+
+    var isExpired: Bool {
+        guard let expiresAt else { return false }
+        return expiresAt < Date()
+    }
+}

--- a/Models/LocalDatabase/PipelineLatencySample.swift
+++ b/Models/LocalDatabase/PipelineLatencySample.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftData
+
+
+
+@Model
+final class PipelineLatencySample {
+    @Attribute(.unique) var id: UUID
+    var stage: String         // raw value of LatencySample.Stage
+    var durationMs: Double
+    var timestamp: Date
+
+    init(id: UUID = UUID(),
+         stage: String,
+         durationMs: Double,
+         timestamp: Date = Date()) {
+        self.id = id
+        self.stage = stage
+        self.durationMs = durationMs
+        self.timestamp = timestamp
+    }
+}

--- a/Services/Analytics/AnalyticsLogService.swift
+++ b/Services/Analytics/AnalyticsLogService.swift
@@ -25,6 +25,17 @@ actor AnalyticsLogService {
             events.removeFirst(events.count - maxEvents / 2)
         }
         persist()
+
+        let kindRaw = event.kind.rawValue
+        let attrs = event.attributes
+        let ts = event.timestamp
+        Task { @MainActor in
+            LocalDatabaseService.shared.insertAnalyticsEvent(
+                kind: kindRaw,
+                attributes: attrs,
+                timestamp: ts
+            )
+        }
     }
 
     func record(kind: AnalyticsEvent.Kind, attributes: [String: String] = [:]) {

--- a/Services/Analytics/PipelineLogger.swift
+++ b/Services/Analytics/PipelineLogger.swift
@@ -42,16 +42,37 @@ actor PipelineLogger {
     func end(_ token: Token) {
         loadIfNeeded()
         let ms = Date().timeIntervalSince(token.start) * 1000
-        samples.append(LatencySample(stage: token.stage, durationMs: ms, timestamp: Date()))
+        let now = Date()
+        samples.append(LatencySample(stage: token.stage, durationMs: ms, timestamp: now))
         if samples.count > cap { samples.removeFirst(samples.count - cap / 2) }
         persist()
+
+
+        let stage = token.stage.rawValue
+        Task { @MainActor in
+            LocalDatabaseService.shared.insertPipelineLatency(
+                stage: stage,
+                durationMs: ms,
+                timestamp: now
+            )
+        }
     }
 
     func recordExternal(stage: LatencySample.Stage, durationMs: Double) {
         loadIfNeeded()
-        samples.append(LatencySample(stage: stage, durationMs: durationMs, timestamp: Date()))
+        let now = Date()
+        samples.append(LatencySample(stage: stage, durationMs: durationMs, timestamp: now))
         if samples.count > cap { samples.removeFirst(samples.count - cap / 2) }
         persist()
+
+        let stageRaw = stage.rawValue
+        Task { @MainActor in
+            LocalDatabaseService.shared.insertPipelineLatency(
+                stage: stageRaw,
+                durationMs: durationMs,
+                timestamp: now
+            )
+        }
     }
 
     func recentSamples(within days: Int = 30) -> [LatencySample] {


### PR DESCRIPTION
Nuevas entidades SwiftData

Models/LocalDatabase/PipelineLatencySample.swift
  Backing relacional de los samples de PipelineLogger (BQ1).
Models/LocalDatabase/AnalyticsEventSample.swift
  Backing relacional de los eventos de AnalyticsLogService (BQ5/7/8).
Models/LocalDatabase/LocalKeyValueEntry.swift
  Tabla key→value con TTL opcional. Backing del LocalKeyValueStore.

Servicio nuevo
Services/LocalDatabase/LocalKeyValueStore.swift
  Hace JSON encode/decode automático. TTL opcional.

Dual-write desde los actors existentes

PipelineLogger.end() y .recordExternal() ahora hacen dual-write vía
  `LocalDatabaseService.insertPipelineLatency(...)` además del JSON.
  BQ1 sigue leyendo del JSON (cero regresión), la tabla SwiftData
  habilita queries con `@Query` y predicados.
AnalyticsLogService.record() hace lo mismo vía
  `insertAnalyticsEvent(...)`. BQ5/7/8 siguen offline-first.

Bootstrap
`LocalDatabaseService.bootstrapLaunchEvent()` ahora también dispara
  1 ingestion latency + 1 featureAccessed event + 1 KV entry
  `lastLaunchAt`. Garantiza que las 6 tablas tengan contenido visible
  desde el primer cold-start.
