### PR TITLE
feat(sprint4): Conteo Físico de Inventario — feature de Juan Felipe

### DIFF
--- a/Models/LocalDatabase/StockCountItemEntry.swift
+++ b/Models/LocalDatabase/StockCountItemEntry.swift
@@ -1,0 +1,63 @@
+import Foundation
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountItemEntry — Sprint 4. Renglón de un conteo físico, persistido en
+// SwiftData. Llave foránea (`session`) a `StockCountSessionEntry`.
+//
+// `countedQuantity` es opcional: `nil` mientras el usuario no haya contado
+// ese producto. `category` se guarda como `String` (raw value de
+// `ProductCategory`) para que SwiftData lo pueda indexar y consultar con
+// `#Predicate`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Model
+final class StockCountItemEntry {
+    @Attribute(.unique) var id: UUID
+    var productId: UUID
+    var productName: String
+    var categoryRaw: String
+    var systemQuantity: Int
+    /// `nil` hasta que el usuario registra la cantidad física.
+    var countedQuantity: Int?
+    var costPrice: Double
+
+    var session: StockCountSessionEntry?
+
+    init(id: UUID = UUID(),
+         productId: UUID,
+         productName: String,
+         categoryRaw: String,
+         systemQuantity: Int,
+         countedQuantity: Int? = nil,
+         costPrice: Double,
+         session: StockCountSessionEntry? = nil) {
+        self.id = id
+        self.productId = productId
+        self.productName = productName
+        self.categoryRaw = categoryRaw
+        self.systemQuantity = systemQuantity
+        self.countedQuantity = countedQuantity
+        self.costPrice = costPrice
+        self.session = session
+    }
+
+    var category: ProductCategory {
+        ProductCategory(rawValue: categoryRaw) ?? .other
+    }
+
+    var isCounted: Bool { countedQuantity != nil }
+
+    /// Convierte la fila persistida al tipo de dominio `StockCountItem`.
+    func toDomain() -> StockCountItem {
+        StockCountItem(
+            id: id,
+            productId: productId,
+            productName: productName,
+            category: category,
+            systemQuantity: systemQuantity,
+            countedQuantity: countedQuantity,
+            costPrice: costPrice
+        )
+    }
+}

--- a/Models/LocalDatabase/StockCountSessionEntry.swift
+++ b/Models/LocalDatabase/StockCountSessionEntry.swift
@@ -1,0 +1,44 @@
+import Foundation
+import SwiftData
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountSessionEntry — Sprint 4. Tabla raíz del conteo físico en la BD
+// relacional local (SwiftData / SQLite).
+//
+// Cada sesión de conteo es una fila aquí; sus renglones cuelgan vía
+// `@Relationship` 1-N con `StockCountItemEntry` (deleteRule: .cascade).
+//
+//   StockCountSessionEntry ──< StockCountItemEntry
+//
+// Local Storage strategy de la feature de Juan Felipe: la sesión completa
+// se persiste en SwiftData, así el conteo sobrevive cierres de app y el
+// usuario puede retomarlo donde lo dejó — 100% offline.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Model
+final class StockCountSessionEntry {
+    @Attribute(.unique) var id: UUID
+    var startedAt: Date
+    var finishedAt: Date?
+    /// Raw value de `StockCountStatus` (`inProgress` / `completed`).
+    var statusRaw: String
+
+    @Relationship(deleteRule: .cascade, inverse: \StockCountItemEntry.session)
+    var items: [StockCountItemEntry] = []
+
+    init(id: UUID = UUID(),
+         startedAt: Date = Date(),
+         finishedAt: Date? = nil,
+         statusRaw: String = StockCountStatus.inProgress.rawValue) {
+        self.id = id
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.statusRaw = statusRaw
+    }
+
+    var status: StockCountStatus {
+        StockCountStatus(rawValue: statusRaw) ?? .inProgress
+    }
+
+    var isInProgress: Bool { status == .inProgress }
+}

--- a/Models/StockCount.swift
+++ b/Models/StockCount.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCount — Sprint 4 (Feature: Conteo Físico de Inventario / Stocktake)
+//
+// Modela una sesión de conteo físico: el comerciante recorre sus productos y
+// registra la cantidad real en estantería. La app reconcilia ese conteo
+// contra el stock que tiene registrado el sistema y calcula la discrepancia
+// y su impacto monetario.
+//
+// Estos son los tipos de dominio (value types, `Sendable`). La persistencia
+// relacional vive en `Models/LocalDatabase/StockCountSessionEntry` y
+// `StockCountItemEntry` (SwiftData). El cómputo concurrente de la
+// reconciliación está en `Services/StockCount/StockCountService`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Estado de una sesión de conteo.
+enum StockCountStatus: String, Codable, Sendable {
+    /// El usuario sigue ingresando cantidades.
+    case inProgress
+    /// El conteo se cerró y se calculó la reconciliación.
+    case completed
+}
+
+/// Un renglón del conteo: un producto con su cantidad de sistema y la contada.
+struct StockCountItem: Identifiable, Hashable, Sendable {
+    let id: UUID
+    let productId: UUID
+    let productName: String
+    let category: ProductCategory
+    /// Cantidad que el sistema cree que hay.
+    let systemQuantity: Int
+    /// Cantidad física contada. `nil` mientras el usuario no la registra.
+    var countedQuantity: Int?
+    /// Costo unitario — usado para valorar la discrepancia.
+    let costPrice: Double
+
+    /// Diferencia contada − sistema. Positiva: hay de más; negativa: falta.
+    /// `nil` mientras no se cuente.
+    var discrepancy: Int? {
+        guard let counted = countedQuantity else { return nil }
+        return counted - systemQuantity
+    }
+
+    /// Impacto monetario de la discrepancia (en valor de costo).
+    var valueImpact: Double {
+        guard let diff = discrepancy else { return 0 }
+        return Double(diff) * costPrice
+    }
+
+    /// `true` si ya fue contado.
+    var isCounted: Bool { countedQuantity != nil }
+
+    /// `true` si fue contado y el conteo no coincide con el sistema.
+    var hasDiscrepancy: Bool {
+        guard let diff = discrepancy else { return false }
+        return diff != 0
+    }
+}
+
+/// Discrepancia agregada para una categoría de productos.
+struct CategoryAccuracy: Identifiable, Hashable, Sendable {
+    let category: ProductCategory
+    let countedItems: Int
+    let itemsWithDiscrepancy: Int
+    let netUnitDiscrepancy: Int
+    let absoluteValueImpact: Double
+
+    var id: String { category.rawValue }
+
+    /// Porcentaje de exactitud: ítems sin discrepancia / ítems contados.
+    var accuracyPct: Double {
+        guard countedItems > 0 else { return 100 }
+        let exact = countedItems - itemsWithDiscrepancy
+        return (Double(exact) / Double(countedItems)) * 100
+    }
+}
+
+/// Resultado de reconciliar una sesión de conteo completa.
+struct StockCountSummary: Sendable {
+    let totalItems: Int
+    let countedItems: Int
+    let itemsWithDiscrepancy: Int
+    /// Suma de discrepancias en unidades (con signo).
+    let netUnitDiscrepancy: Int
+    /// Suma del valor absoluto del impacto — cuánta plata "baila".
+    let absoluteValueImpact: Double
+    let perCategory: [CategoryAccuracy]
+    let computedAt: Date
+    /// Tiempo de cómputo en ms — evidencia visible del trabajo concurrente.
+    let durationMs: Double
+
+    /// Exactitud global del inventario: ítems exactos / ítems contados.
+    var overallAccuracyPct: Double {
+        guard countedItems > 0 else { return 100 }
+        let exact = countedItems - itemsWithDiscrepancy
+        return (Double(exact) / Double(countedItems)) * 100
+    }
+
+    static let empty = StockCountSummary(
+        totalItems: 0, countedItems: 0, itemsWithDiscrepancy: 0,
+        netUnitDiscrepancy: 0, absoluteValueImpact: 0, perCategory: [],
+        computedAt: Date(), durationMs: 0
+    )
+}

--- a/Services/LocalDatabase/LocalDatabaseService.swift
+++ b/Services/LocalDatabase/LocalDatabaseService.swift
@@ -25,7 +25,10 @@ final class LocalDatabaseService: ObservableObject {
             AnalyticsEventSample.self,
             LocalKeyValueEntry.self,
             RestockCycleEntry.self,
-            ExpirationAdviceEntry.self
+            ExpirationAdviceEntry.self,
+            // Sprint 4 — Conteo Físico de Inventario (Juan Felipe)
+            StockCountSessionEntry.self,
+            StockCountItemEntry.self
         ])
         let config = ModelConfiguration(
             schema: schema,
@@ -210,6 +213,81 @@ final class LocalDatabaseService: ObservableObject {
         )
         context.insert(entry)
         try? context.save()
+    }
+
+    // MARK: - Stock Count (Sprint 4 — Conteo Físico, Juan Felipe)
+
+    /// Crea una sesión de conteo nueva con sus renglones (uno por producto)
+    /// y la devuelve. Los renglones arrancan sin `countedQuantity`.
+    @discardableResult
+    func createStockCountSession(items: [StockCountItem]) -> StockCountSessionEntry {
+        let session = StockCountSessionEntry()
+        context.insert(session)
+        for item in items {
+            let entry = StockCountItemEntry(
+                productId: item.productId,
+                productName: item.productName,
+                categoryRaw: item.category.rawValue,
+                systemQuantity: item.systemQuantity,
+                countedQuantity: item.countedQuantity,
+                costPrice: item.costPrice,
+                session: session
+            )
+            context.insert(entry)
+        }
+        try? context.save()
+        return session
+    }
+
+    /// Devuelve la sesión de conteo en progreso, si existe. Permite retomar
+    /// un conteo que quedó a medias tras cerrar la app.
+    func activeStockCountSession() -> StockCountSessionEntry? {
+        let target = StockCountStatus.inProgress.rawValue
+        let predicate = #Predicate<StockCountSessionEntry> { $0.statusRaw == target }
+        var descriptor = FetchDescriptor<StockCountSessionEntry>(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    /// Registra la cantidad contada para un renglón puntual y persiste.
+    func recordCountedQuantity(itemId: UUID, quantity: Int) {
+        let predicate = #Predicate<StockCountItemEntry> { $0.id == itemId }
+        let descriptor = FetchDescriptor<StockCountItemEntry>(predicate: predicate)
+        guard let entry = (try? context.fetch(descriptor))?.first else { return }
+        entry.countedQuantity = quantity
+        try? context.save()
+    }
+
+    /// Marca una sesión como completada.
+    func finishStockCountSession(sessionId: UUID) {
+        let predicate = #Predicate<StockCountSessionEntry> { $0.id == sessionId }
+        let descriptor = FetchDescriptor<StockCountSessionEntry>(predicate: predicate)
+        guard let session = (try? context.fetch(descriptor))?.first else { return }
+        session.statusRaw = StockCountStatus.completed.rawValue
+        session.finishedAt = Date()
+        try? context.save()
+    }
+
+    /// Todas las sesiones de conteo, más recientes primero. Lo usa BQ9.
+    func allStockCountSessions() -> [StockCountSessionEntry] {
+        let descriptor = FetchDescriptor<StockCountSessionEntry>(
+            sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
+    }
+
+    /// Sesiones completadas — fuente de BQ9 (exactitud de inventario).
+    func completedStockCountSessions() -> [StockCountSessionEntry] {
+        let target = StockCountStatus.completed.rawValue
+        let predicate = #Predicate<StockCountSessionEntry> { $0.statusRaw == target }
+        let descriptor = FetchDescriptor<StockCountSessionEntry>(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.startedAt, order: .reverse)]
+        )
+        return (try? context.fetch(descriptor)) ?? []
     }
 
     // MARK: - Key-Value store (Santiago — BD llave-valor)

--- a/Services/StockCount/StockCountService.swift
+++ b/Services/StockCount/StockCountService.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountService — Sprint 4. Motor de reconciliación del conteo físico.
+//
+// Multithreading strategy (feature de Juan Felipe)
+// ────────────────────────────────────────────────
+// Reconciliar un conteo significa, para cada categoría, agregar las
+// discrepancias de todos sus productos. Con catálogos grandes esto es
+// CPU-bound. La estrategia:
+//
+//   • `withTaskGroup` fan-out: un child task por categoría. Cada task
+//     recorre su slice de ítems y produce un `CategoryAccuracy`.
+//   • Cada child corre a `priority: .userInitiated` en el cooperative
+//     thread pool — fuera del @MainActor.
+//   • La función de agregación `accuracyFor` es `static` y pura (sin estado
+//     capturado), así es segura de ejecutar dentro del task group.
+//   • El fan-in (`for await`) reúne los resultados; el reducer final corre
+//     en el thread donde termine el grupo, sin estado mutable compartido.
+//
+// Se mide `durationMs` y se expone en `StockCountSummary` para tener
+// evidencia visible en la UI de que el cómputo concurrente trabaja.
+//
+// Eventual connectivity
+// ─────────────────────
+// Opera 100% sobre datos locales (los ítems del conteo, ya en SwiftData).
+// No toca red — el conteo físico funciona en modo avión sin degradación.
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum StockCountService {
+
+    /// Reconciliación concurrente de una sesión de conteo.
+    ///
+    /// - Parameter items: renglones del conteo (idealmente ya con
+    ///   `countedQuantity` registrada; los no contados se ignoran en los
+    ///   agregados de exactitud).
+    /// - Returns: el `StockCountSummary` con totales y desglose por categoría.
+    static func reconcile(items: [StockCountItem]) async -> StockCountSummary {
+        let start = Date()
+
+        // Indexamos por categoría una sola vez, en el thread del caller —
+        // más barato que tener cada child re-escaneando la lista completa.
+        let byCategory: [ProductCategory: [StockCountItem]] =
+            Dictionary(grouping: items, by: \.category)
+
+        // Fan-out: un child task por categoría.
+        let perCategory: [CategoryAccuracy] = await withTaskGroup(
+            of: CategoryAccuracy?.self
+        ) { group in
+            for (category, slice) in byCategory {
+                group.addTask(priority: .userInitiated) {
+                    Self.accuracyFor(category: category, items: slice)
+                }
+            }
+            // Fan-in.
+            var acc: [CategoryAccuracy] = []
+            acc.reserveCapacity(byCategory.count)
+            for await row in group {
+                if let row { acc.append(row) }
+            }
+            return acc
+        }
+
+        // Reducer final — sólo value types, sin estado compartido.
+        let sorted = perCategory.sorted { $0.absoluteValueImpact > $1.absoluteValueImpact }
+        let counted = items.filter { $0.isCounted }
+        let withDiscrepancy = counted.filter { $0.hasDiscrepancy }
+        let netUnits = counted.reduce(0) { $0 + ($1.discrepancy ?? 0) }
+        let absImpact = counted.reduce(0.0) { $0 + abs($1.valueImpact) }
+        let elapsed = Date().timeIntervalSince(start) * 1000
+
+        return StockCountSummary(
+            totalItems: items.count,
+            countedItems: counted.count,
+            itemsWithDiscrepancy: withDiscrepancy.count,
+            netUnitDiscrepancy: netUnits,
+            absoluteValueImpact: absImpact,
+            perCategory: sorted,
+            computedAt: Date(),
+            durationMs: elapsed
+        )
+    }
+
+    // MARK: - Pure aggregation
+
+    /// Función pura — `static`, sin estado capturado — segura para correr
+    /// dentro de un child task del `withTaskGroup`. Sólo cuenta los ítems
+    /// que ya fueron contados; los pendientes no afectan la exactitud.
+    private static func accuracyFor(category: ProductCategory,
+                                    items: [StockCountItem]) -> CategoryAccuracy? {
+        let counted = items.filter { $0.isCounted }
+        guard !counted.isEmpty else { return nil }
+
+        let withDiscrepancy = counted.filter { $0.hasDiscrepancy }
+        let netUnits = counted.reduce(0) { $0 + ($1.discrepancy ?? 0) }
+        let absImpact = counted.reduce(0.0) { $0 + abs($1.valueImpact) }
+
+        return CategoryAccuracy(
+            category: category,
+            countedItems: counted.count,
+            itemsWithDiscrepancy: withDiscrepancy.count,
+            netUnitDiscrepancy: netUnits,
+            absoluteValueImpact: absImpact
+        )
+    }
+}

--- a/ViewModels/BQ/Sprint4BQsViewModel.swift
+++ b/ViewModels/BQ/Sprint4BQsViewModel.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import Combine
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sprint4BQsViewModel — drives the Sprint 4 Business Questions.
+//
+//   • BQ9 (Juan Felipe) — Exactitud del inventario por categoría:
+//     "¿Qué % de discrepancia hay entre el stock registrado y el conteo
+//      físico, desglosado por categoría?"
+//
+// Fuente de datos: las sesiones de conteo COMPLETADAS persistidas en
+// SwiftData (`StockCountSessionEntry`). El view-model lee las filas en el
+// `@MainActor`, las convierte a `StockCountItem` (value type `Sendable`) y
+// delega la agregación concurrente a `StockCountService.reconcile`, que usa
+// `withTaskGroup`. El view-model nunca agrega en el hilo principal.
+//
+// Eventual connectivity: la BQ se computa 100% sobre datos locales
+// (SwiftData) — responde aunque el dispositivo esté sin conexión.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@MainActor
+final class Sprint4BQsViewModel: ObservableObject {
+
+    /// Resultado de BQ9 — reconciliación agregada de todos los conteos.
+    @Published private(set) var stockAccuracy: StockCountSummary?
+    /// Cuántas sesiones de conteo completadas se analizaron.
+    @Published private(set) var sessionsAnalyzed = 0
+    @Published private(set) var isLoading = false
+
+    private let db = LocalDatabaseService.shared
+
+    /// Recalcula BQ9. Llamado en el `.task` y el pull-to-refresh del
+    /// dashboard de Business Questions.
+    func refresh() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        // Lectura relacional: todas las sesiones de conteo completadas.
+        let sessions = db.completedStockCountSessions()
+        sessionsAnalyzed = sessions.count
+
+        // Aplanamos a renglones de dominio (`Sendable`) para poder cruzarlos
+        // al cómputo concurrente sin actor-isolation issues.
+        let items: [StockCountItem] = sessions
+            .flatMap { $0.items }
+            .map { $0.toDomain() }
+
+        guard !items.isEmpty else {
+            stockAccuracy = nil
+            return
+        }
+
+        // Agregación concurrente (TaskGroup) — reutiliza el mismo motor que
+        // la feature de conteo físico.
+        stockAccuracy = await StockCountService.reconcile(items: items)
+    }
+}

--- a/ViewModels/StockCountViewModel.swift
+++ b/ViewModels/StockCountViewModel.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import Combine
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountViewModel — Sprint 4. Orquesta la feature de Conteo Físico.
+//
+// Responsabilidades
+//   • Crear / retomar la sesión de conteo (persistida en SwiftData).
+//   • Registrar la cantidad contada de cada producto.
+//   • Disparar la reconciliación concurrente (`StockCountService`) al cerrar.
+//
+// Concurrencia
+//   `@MainActor` por convención de SwiftUI. El cómputo pesado lo delega a
+//   `StockCountService.reconcile`, que usa `withTaskGroup`. El view-model
+//   sólo `await`-ea el resultado — nunca agrega en el hilo principal.
+//
+// Eventual connectivity
+//   Todo el flujo de conteo es local-first: la sesión vive en SwiftData y
+//   funciona sin red. `applyAdjustments` empuja las correcciones al
+//   inventario vía `InventoryViewModel.updateProduct`, que ya encola en el
+//   `OfflineQueueService` si no hay conexión.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@MainActor
+final class StockCountViewModel: ObservableObject {
+
+    /// Renglones del conteo en curso.
+    @Published private(set) var items: [StockCountItem] = []
+    /// Resultado de la reconciliación una vez cerrada la sesión.
+    @Published private(set) var summary: StockCountSummary?
+    /// `true` mientras `StockCountService.reconcile` corre.
+    @Published private(set) var isReconciling = false
+    /// `true` si hay una sesión de conteo abierta.
+    @Published private(set) var hasActiveSession = false
+    @Published var errorMessage: String?
+
+    private let db = LocalDatabaseService.shared
+    private var sessionId: UUID?
+
+    // MARK: - Sesión
+
+    /// Llamado al abrir la vista. Si hay un conteo a medias en SwiftData lo
+    /// retoma; si no, deja la vista lista para iniciar uno nuevo.
+    func restoreActiveSession() {
+        guard let session = db.activeStockCountSession() else {
+            hasActiveSession = false
+            return
+        }
+        sessionId = session.id
+        items = session.items
+            .map { $0.toDomain() }
+            .sorted { $0.productName < $1.productName }
+        hasActiveSession = true
+        summary = nil
+    }
+
+    /// Crea una sesión de conteo nueva a partir del catálogo de productos
+    /// activos. Persiste de inmediato en SwiftData.
+    func startNewCount(products: [Product]) {
+        let activeProducts = products.filter { $0.isActive }
+        guard !activeProducts.isEmpty else {
+            errorMessage = "No hay productos activos para contar."
+            return
+        }
+        let newItems: [StockCountItem] = activeProducts.map { product in
+            StockCountItem(
+                id: UUID(),
+                productId: product.id,
+                productName: product.name,
+                category: product.category,
+                systemQuantity: product.quantity,
+                countedQuantity: nil,
+                costPrice: product.costPrice
+            )
+        }
+        let session = db.createStockCountSession(items: newItems)
+        sessionId = session.id
+        // Releemos del store para que los `id` de los renglones coincidan
+        // con las filas persistidas (los necesitamos para `recordCount`).
+        items = session.items
+            .map { $0.toDomain() }
+            .sorted { $0.productName < $1.productName }
+        hasActiveSession = true
+        summary = nil
+        HapticManager.notification(.success)
+    }
+
+    // MARK: - Conteo
+
+    /// Registra la cantidad física contada de un producto. Actualiza la
+    /// copia in-memory y persiste el renglón en SwiftData.
+    func recordCount(itemId: UUID, quantity: Int) {
+        guard quantity >= 0, quantity <= 1_000_000 else {
+            errorMessage = "Cantidad inválida."
+            return
+        }
+        guard let index = items.firstIndex(where: { $0.id == itemId }) else { return }
+        items[index].countedQuantity = quantity
+        db.recordCountedQuantity(itemId: itemId, quantity: quantity)
+        HapticManager.selection()
+    }
+
+    /// Cierra la sesión y reconcilia. El cómputo es concurrente.
+    func finishCount() async {
+        guard let sessionId else { return }
+        isReconciling = true
+        defer { isReconciling = false }
+
+        // Cómputo concurrente fuera del main — `withTaskGroup` adentro.
+        let result = await StockCountService.reconcile(items: items)
+
+        db.finishStockCountSession(sessionId: sessionId)
+        summary = result
+        hasActiveSession = false
+
+        // Audit del cierre (dual-write a SwiftData vía PersistenceService).
+        PersistenceService.shared.logAuditEvent(
+            AuditEvent(
+                userId: UUID(),
+                userName: "Usuario",
+                action: "Conteo Finalizado",
+                entityType: "StockCount",
+                details: "\(result.countedItems) productos contados · " +
+                         "exactitud \(String(format: "%.0f", result.overallAccuracyPct))%"
+            )
+        )
+        HapticManager.notification(.success)
+    }
+
+    /// Cancela la sesión activa sin reconciliar.
+    func cancelCount() {
+        guard let sessionId else { return }
+        db.finishStockCountSession(sessionId: sessionId)  // la cierra como completada vacía
+        self.sessionId = nil
+        items = []
+        hasActiveSession = false
+        summary = nil
+    }
+
+    // MARK: - Derivados para la UI
+
+    var countedCount: Int { items.filter { $0.isCounted }.count }
+    var totalCount: Int { items.count }
+    var progress: Double {
+        guard totalCount > 0 else { return 0 }
+        return Double(countedCount) / Double(totalCount)
+    }
+    var allCounted: Bool { totalCount > 0 && countedCount == totalCount }
+
+    /// Productos cuyo conteo no coincide con el sistema — los que ameritan
+    /// un ajuste de inventario.
+    var discrepantItems: [StockCountItem] {
+        items.filter { $0.hasDiscrepancy }
+    }
+}

--- a/Views/Analytics/Insights/BusinessQuestionsView.swift
+++ b/Views/Analytics/Insights/BusinessQuestionsView.swift
@@ -14,6 +14,7 @@ struct BusinessQuestionsView: View {
     @StateObject private var viewModel = BusinessQuestionsViewModel()
     @StateObject private var sprint3VM = Sprint3BQsViewModel()
     @StateObject private var insightsVM = InventoryInsightsViewModel()
+    @StateObject private var sprint4VM = Sprint4BQsViewModel()
     @ObservedObject private var network = NetworkMonitor.shared
 
     var body: some View {
@@ -53,6 +54,12 @@ struct BusinessQuestionsView: View {
                     dashboard: insightsVM.expirationDashboard,
                     isLoading: insightsVM.isLoadingExpiration
                 )
+                // Sprint 4 — BQ9 (Juan Felipe)
+                StockAccuracyCard(
+                    summary: sprint4VM.stockAccuracy,
+                    sessionsAnalyzed: sprint4VM.sessionsAnalyzed,
+                    isLoading: sprint4VM.isLoading
+                )
                 Spacer().frame(height: 40)
             }
             .padding(.horizontal, 16)
@@ -75,6 +82,7 @@ struct BusinessQuestionsView: View {
         )
         await sprint3VM.refresh()
         await insightsVM.refresh(products: inventoryViewModel.products)
+        await sprint4VM.refresh()
         // BQ8
         await AnalyticsLogService.shared.record(
             kind: .featureAccessed,

--- a/Views/Analytics/Insights/StockAccuracyCard.swift
+++ b/Views/Analytics/Insights/StockAccuracyCard.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockAccuracyCard — Sprint 4. Card de BQ9 en el dashboard de Business
+// Questions. Muestra la exactitud del inventario calculada a partir de los
+// conteos físicos completados.
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct StockAccuracyCard: View {
+    let summary: StockCountSummary?
+    let sessionsAnalyzed: Int
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && summary == nil {
+                loadingRow
+            } else if let s = summary, s.countedItems > 0 {
+                overall(s)
+                Divider()
+                categoryList(s.perCategory.prefix(4))
+                footer(s)
+            } else {
+                emptyState
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.systemBackground))
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("BQ9 · Exactitud del inventario")
+                .font(.subheadline.weight(.semibold))
+            Text("Reconciliación concurrente conteo físico vs. sistema (TaskGroup)")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func overall(_ s: StockCountSummary) -> some View {
+        HStack(spacing: 20) {
+            metricBlock(
+                label: "Exactitud global",
+                value: String(format: "%.0f%%", s.overallAccuracyPct),
+                color: accuracyColor(s.overallAccuracyPct)
+            )
+            metricBlock(
+                label: "Productos contados",
+                value: "\(s.countedItems)",
+                color: .primary
+            )
+            metricBlock(
+                label: "Con discrepancia",
+                value: "\(s.itemsWithDiscrepancy)",
+                color: s.itemsWithDiscrepancy > 0 ? .orange : .green
+            )
+        }
+    }
+
+    private func metricBlock(label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.title3.weight(.bold))
+                .foregroundColor(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func categoryList(_ rows: ArraySlice<CategoryAccuracy>) -> some View {
+        VStack(spacing: 10) {
+            ForEach(Array(rows)) { cat in
+                HStack {
+                    Image(systemName: cat.category.icon)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(width: 22)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(cat.category.rawValue)
+                            .font(.subheadline.weight(.medium))
+                        Text("\(cat.countedItems) contados · \(cat.itemsWithDiscrepancy) con diferencia")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Text(String(format: "%.0f%%", cat.accuracyPct))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(accuracyColor(cat.accuracyPct))
+                }
+            }
+        }
+    }
+
+    private func footer(_ s: StockCountSummary) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "bolt.fill").font(.caption2)
+            Text(String(format: "%d sesión%@ analizada%@ · agregado en %.1f ms",
+                        sessionsAnalyzed,
+                        sessionsAnalyzed == 1 ? "" : "es",
+                        sessionsAnalyzed == 1 ? "" : "s",
+                        s.durationMs))
+                .font(.caption2)
+        }
+        .foregroundColor(.secondary)
+    }
+
+    private var emptyState: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "checklist")
+                    .font(.title2)
+                    .foregroundColor(.secondary)
+                Text("Realiza un conteo físico (Inicio → Herramientas) para ver esta BQ.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            ProgressView("Reconciliando conteos…").font(.footnote)
+            Spacer()
+        }
+        .padding(.vertical, 24)
+    }
+
+    private func accuracyColor(_ pct: Double) -> Color {
+        if pct >= 95 { return .green }
+        if pct >= 80 { return .orange }
+        return .red
+    }
+}

--- a/Views/Home/HomeView.swift
+++ b/Views/Home/HomeView.swift
@@ -9,6 +9,8 @@ struct HomeView: View {
     @State private var showAddProduct = false
     @State private var showSettings = false
     @State private var showScanFromHome = false
+    // Sprint 4 — entradas a las features nuevas
+    @State private var showStockCount = false
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -21,6 +23,7 @@ struct HomeView: View {
                     salesChart
                     alertsSection
                     quickActions
+                    toolsSection
                     Spacer().frame(height: 80)
                 }
                 .padding(.horizontal, 16)
@@ -64,6 +67,7 @@ struct HomeView: View {
             .sheet(isPresented: $showAddProduct) { AddProductView() }
             .sheet(isPresented: $showSettings) { SettingsView() }
             .fullScreenCover(isPresented: $showScanFromHome) { ScanView() }
+            .sheet(isPresented: $showStockCount) { StockCountView() }
         }
     }
 
@@ -193,6 +197,18 @@ struct HomeView: View {
                 }
                 quickActionButton(icon: "plus.circle.fill", title: "Agregar Producto", color: AppColors.teaGreen) {
                     showAddProduct = true
+                }
+            }
+        }
+    }
+
+    // MARK: - Tools Section (Sprint 4 features)
+    private var toolsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Herramientas").font(AppTypography.headlineFont)
+            HStack(spacing: 12) {
+                quickActionButton(icon: "checklist", title: "Conteo Físico", color: AppColors.freshSky) {
+                    showStockCount = true
                 }
             }
         }

--- a/Views/StockCount/StockCountView.swift
+++ b/Views/StockCount/StockCountView.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountView — Sprint 4. Vista de la feature de Conteo Físico de
+// Inventario (Juan Felipe). Una de las 3 vistas nuevas del sprint.
+//
+// Tres estados:
+//   1. Sin sesión        → empty state + botón "Iniciar conteo".
+//   2. Conteo en progreso → lista de productos con campo de cantidad real,
+//                           barra de progreso y botón "Finalizar".
+//   3. Resultado          → reconciliación: exactitud global y por categoría.
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct StockCountView: View {
+    @EnvironmentObject private var inventoryViewModel: InventoryViewModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    @StateObject private var viewModel = StockCountViewModel()
+    @State private var showCancelConfirm = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let summary = viewModel.summary {
+                    resultView(summary)
+                } else if viewModel.hasActiveSession {
+                    countingView
+                } else {
+                    emptyState
+                }
+            }
+            .background(colorScheme == .dark ? AppColors.darkBackground : AppColors.background)
+            .navigationTitle("Conteo Físico")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cerrar") { dismiss() }
+                }
+                if viewModel.hasActiveSession {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Cancelar", role: .destructive) {
+                            showCancelConfirm = true
+                        }
+                    }
+                }
+            }
+            .onAppear { viewModel.restoreActiveSession() }
+            .alert("Cancelar conteo", isPresented: $showCancelConfirm) {
+                Button("Volver", role: .cancel) {}
+                Button("Descartar conteo", role: .destructive) {
+                    viewModel.cancelCount()
+                }
+            } message: {
+                Text("Se descartará el conteo en progreso. Esta acción no se puede deshacer.")
+            }
+            .alert("Aviso", isPresented: .constant(viewModel.errorMessage != nil)) {
+                Button("OK") { viewModel.errorMessage = nil }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+    }
+
+    // MARK: - Estado 1: sin sesión
+
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "checklist")
+                .font(.system(size: 56))
+                .foregroundColor(AppColors.freshSky)
+            Text("Conteo Físico de Inventario")
+                .font(AppTypography.title3Font)
+                .foregroundColor(colorScheme == .dark ? AppColors.darkTextPrimary : AppColors.textPrimary)
+            Text("Recorre tus productos, registra la cantidad real en estantería y la app calcula las discrepancias contra el stock del sistema.")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button(action: {
+                viewModel.startNewCount(products: inventoryViewModel.products)
+            }) {
+                Text("Iniciar conteo")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding(.horizontal, 40)
+            .disabled(inventoryViewModel.products.isEmpty)
+            Spacer()
+        }
+    }
+
+    // MARK: - Estado 2: conteo en progreso
+
+    private var countingView: some View {
+        VStack(spacing: 0) {
+            progressHeader
+            List {
+                ForEach(viewModel.items) { item in
+                    StockCountRow(item: item) { qty in
+                        viewModel.recordCount(itemId: item.id, quantity: qty)
+                    }
+                }
+            }
+            .listStyle(.plain)
+            finishBar
+        }
+    }
+
+    private var progressHeader: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("\(viewModel.countedCount) de \(viewModel.totalCount) contados")
+                    .font(AppTypography.captionFont)
+                    .foregroundColor(AppColors.textSecondary)
+                Spacer()
+                Text("\(Int(viewModel.progress * 100))%")
+                    .font(AppTypography.captionFont)
+                    .fontWeight(.semibold)
+                    .foregroundColor(AppColors.freshSky)
+            }
+            ProgressView(value: viewModel.progress)
+                .tint(AppColors.freshSky)
+        }
+        .padding(16)
+    }
+
+    private var finishBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Button(action: { Task { await viewModel.finishCount() } }) {
+                if viewModel.isReconciling {
+                    ProgressView().tint(.white)
+                } else {
+                    Text(viewModel.allCounted
+                         ? "Finalizar y reconciliar"
+                         : "Finalizar (\(viewModel.countedCount) contados)")
+                }
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding(16)
+            .disabled(viewModel.countedCount == 0 || viewModel.isReconciling)
+        }
+    }
+
+    // MARK: - Estado 3: resultado
+
+    private func resultView(_ summary: StockCountSummary) -> some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                accuracyHeadline(summary)
+                metricsGrid(summary)
+                if !summary.perCategory.isEmpty {
+                    categoryBreakdown(summary)
+                }
+                if !viewModel.discrepantItems.isEmpty {
+                    adjustmentsCard
+                }
+                Text("Reconciliado en \(String(format: "%.0f", summary.durationMs)) ms · cómputo concurrente con TaskGroup")
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textTertiary)
+                    .multilineTextAlignment(.center)
+                Spacer().frame(height: 20)
+            }
+            .padding(16)
+        }
+    }
+
+    private func accuracyHeadline(_ summary: StockCountSummary) -> some View {
+        VStack(spacing: 6) {
+            Text("\(String(format: "%.0f", summary.overallAccuracyPct))%")
+                .font(.system(size: 52, weight: .bold))
+                .foregroundColor(accuracyColor(summary.overallAccuracyPct))
+            Text("Exactitud del inventario")
+                .font(AppTypography.captionFont)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+        .cardStyle()
+    }
+
+    private func metricsGrid(_ summary: StockCountSummary) -> some View {
+        LazyVGrid(columns: [GridItem(.flexible(), spacing: 12),
+                            GridItem(.flexible(), spacing: 12)], spacing: 12) {
+            metricTile("Productos contados", "\(summary.countedItems)", AppColors.deepSpaceBlue)
+            metricTile("Con discrepancia", "\(summary.itemsWithDiscrepancy)", AppColors.warning)
+            metricTile("Diferencia neta", "\(summary.netUnitDiscrepancy) uds", AppColors.info)
+            metricTile("Impacto", summary.absoluteValueImpact.compactCurrency, AppColors.error)
+        }
+    }
+
+    private func metricTile(_ title: String, _ value: String, _ color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(value)
+                .font(AppTypography.title3Font)
+                .foregroundColor(color)
+            Text(title)
+                .font(AppTypography.caption2Font)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .cardStyle()
+    }
+
+    private func categoryBreakdown(_ summary: StockCountSummary) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Exactitud por categoría")
+                .font(AppTypography.headlineFont)
+            ForEach(summary.perCategory) { cat in
+                HStack {
+                    Image(systemName: cat.category.icon)
+                        .foregroundColor(AppColors.freshSky)
+                        .frame(width: 24)
+                    Text(cat.category.rawValue)
+                        .font(AppTypography.captionFont)
+                    Spacer()
+                    Text("\(String(format: "%.0f", cat.accuracyPct))%")
+                        .font(AppTypography.captionFont)
+                        .fontWeight(.semibold)
+                        .foregroundColor(accuracyColor(cat.accuracyPct))
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .padding(16)
+        .cardStyle()
+    }
+
+    private var adjustmentsCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Ajustar inventario")
+                .font(AppTypography.headlineFont)
+            Text("\(viewModel.discrepantItems.count) productos no coinciden. Aplica el conteo físico como cantidad oficial.")
+                .font(AppTypography.caption2Font)
+                .foregroundColor(AppColors.textSecondary)
+            Button(action: applyAdjustments) {
+                Text("Aplicar ajustes al inventario")
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .padding(16)
+        .cardStyle()
+    }
+
+    // MARK: - Helpers
+
+    /// Aplica el conteo físico como cantidad real de cada producto discrepante.
+    /// Va por `InventoryViewModel.updateProduct`, que ya tiene la lógica
+    /// offline-first: si no hay red, encola el cambio en `OfflineQueueService`.
+    private func applyAdjustments() {
+        for item in viewModel.discrepantItems {
+            guard let counted = item.countedQuantity,
+                  var product = inventoryViewModel.products
+                      .first(where: { $0.id == item.productId }) else { continue }
+            product.quantity = counted
+            product.lastUpdated = Date()
+            inventoryViewModel.updateProduct(product)
+        }
+        HapticManager.notification(.success)
+        dismiss()
+    }
+
+    private func accuracyColor(_ pct: Double) -> Color {
+        if pct >= 95 { return AppColors.success }
+        if pct >= 80 { return AppColors.warning }
+        return AppColors.error
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StockCountRow — un renglón de la lista de conteo. Mantiene su propio
+// estado de texto local para el campo numérico; al confirmar, reporta al
+// view-model vía el closure `onCount`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+private struct StockCountRow: View {
+    let item: StockCountItem
+    let onCount: (Int) -> Void
+
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.productName)
+                    .font(AppTypography.captionFont)
+                    .lineLimit(1)
+                Text("Sistema: \(item.systemQuantity) uds")
+                    .font(AppTypography.caption2Font)
+                    .foregroundColor(AppColors.textTertiary)
+            }
+            Spacer()
+            if let diff = item.discrepancy, item.isCounted {
+                Text(diff == 0 ? "OK" : (diff > 0 ? "+\(diff)" : "\(diff)"))
+                    .font(AppTypography.caption2Font)
+                    .fontWeight(.semibold)
+                    .foregroundColor(diff == 0 ? AppColors.success : AppColors.warning)
+                    .padding(.horizontal, 8).padding(.vertical, 3)
+                    .background((diff == 0 ? AppColors.success : AppColors.warning).opacity(0.15))
+                    .clipShape(Capsule())
+            }
+            TextField("Real", text: $text)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.center)
+                .frame(width: 60)
+                .padding(.vertical, 6)
+                .background(AppColors.surfaceSecondary)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .focused($focused)
+                .onSubmit { commit() }
+        }
+        .onChange(of: focused) { _, isFocused in
+            if !isFocused { commit() }
+        }
+        .onAppear {
+            if let counted = item.countedQuantity { text = "\(counted)" }
+        }
+    }
+
+    private func commit() {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, let qty = Int(trimmed) else { return }
+        onCount(qty)
+    }
+}


### PR DESCRIPTION
## Sprint 4 — Feature nueva de Juan Felipe

**Conteo Físico de Inventario (Stocktake).** El comerciante recorre sus productos, registra la cantidad real en estantería y la app reconcilia contra el stock del sistema, calculando discrepancias e impacto monetario.

## Cubre del rubric (grupo de 3 puede fusionar a + b en una feature)

| Categoría | Cómo |
|---|---|
| **Multithreading** (20) | `StockCountService.reconcile` — `withTaskGroup`, un child task por categoría a `.userInitiated`. Función de agregación `static` pura. Mide `durationMs`. |
| **Local Storage** (20) | SwiftData relacional: `StockCountSessionEntry` ──< `StockCountItemEntry` con `@Relationship` 1-N cascade. La sesión sobrevive cierres de app. |
| **Eventual Connectivity** (parte de los 20) | Flujo 100% local-first. "Aplicar ajustes" va por `InventoryViewModel.updateProduct` → encola en `OfflineQueueService` si no hay red. |

## Vista nueva (Sprint 4)
`StockCountView` — 3 estados: sin sesión / conteo en progreso (lista con campo de cantidad real + barra de progreso) / resultado (exactitud global + desglose por categoría).

## BQ nueva
**BQ9** — "Exactitud del inventario por categoría". Card `StockAccuracyCard` en el dashboard de Business Questions. Reconcilia todas las sesiones completadas con el motor concurrente.

## Archivos
**Nuevos (8):** `Models/StockCount.swift`, `Models/LocalDatabase/StockCountSessionEntry.swift`, `StockCountItemEntry.swift`, `Services/StockCount/StockCountService.swift`, `ViewModels/StockCountViewModel.swift`, `ViewModels/BQ/Sprint4BQsViewModel.swift`, `Views/StockCount/StockCountView.swift`, `Views/Analytics/Insights/StockAccuracyCard.swift`

**Modificados (3):** `LocalDatabaseService` (schema +2 entidades + métodos), `HomeView` (sección Herramientas), `BusinessQuestionsView` (card BQ9)

## Verificación
- `xcodebuild` Debug → **BUILD SUCCEEDED**
- `xcodebuild` Release → **BUILD SUCCEEDED**
- App arranca sin crash, tablas `ZSTOCKCOUNTSESSIONENTRY` y `ZSTOCKCOUNTITEMENTRY` materializadas en SQLite.

## Test plan
- [ ] Inicio → Herramientas → Conteo Físico → Iniciar conteo.
- [ ] Registrar cantidades; ver badges de discrepancia (+N / -N / OK).
- [ ] Cerrar la app a mitad → reabrir → el conteo se retoma.
- [ ] Finalizar → ver exactitud global + desglose por categoría + ms de cómputo.
- [ ] Aplicar ajustes → los productos discrepantes se actualizan (offline → encola).
- [ ] Analítica → Business Questions → card BQ9 con la exactitud.