### PR TITLE
fix(sprint4): restaurar archivos faltantes para que main compile

### DIFF
--- a/Services/PurchaseOrders/PurchaseOrderStore.swift
+++ b/Services/PurchaseOrders/PurchaseOrderStore.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PurchaseOrderStore — Sprint 4. Persistencia + sincronización eventual de
+// las órdenes de compra (feature de Angel).
+//
+// `actor` con backing JSON en Application Support (`purchase_orders.json`).
+//
+// Eventual connectivity strategy
+// ──────────────────────────────
+// Las órdenes se persisten SIEMPRE en local, haya o no conexión. Cada orden
+// lleva un `syncState`:
+//   • `.pendingSync` — creada offline, aún sin reconciliar con backend.
+//   • `.synced`      — ya reconciliada.
+//
+// `syncPending()` recorre las órdenes `.pendingSync` y las reconcilia. Lo
+// dispara el `PurchaseOrderViewModel` cuando detecta que volvió la conexión
+// (vía `ConnectivityService`). El método sólo reconcilia si efectivamente
+// hay red — si no, las deja pendientes para el próximo intento.
+//
+// `// NOTA:` aquí iría el POST real al endpoint `/purchase-orders` del
+// backend. Como el backend de Sprint 4 aún no expone ese endpoint, la
+// reconciliación marca el estado local — exactamente el mismo patrón que
+// `OfflineQueueService` usa para los productos.
+// ─────────────────────────────────────────────────────────────────────────────
+
+actor PurchaseOrderStore {
+    static let shared = PurchaseOrderStore()
+
+    private let fileName = "purchase_orders.json"
+    private var orders: [PurchaseOrder] = []
+    private var loaded = false
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let fileManager = FileManager.default
+
+    private init() {
+        encoder = JSONEncoder(); encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+    }
+
+    // MARK: - Public API
+
+    /// Inserta o actualiza una orden y persiste.
+    func save(_ order: PurchaseOrder) {
+        loadIfNeeded()
+        if let idx = orders.firstIndex(where: { $0.id == order.id }) {
+            orders[idx] = order
+        } else {
+            orders.append(order)
+        }
+        persist()
+        #if DEBUG
+        print("[PurchaseOrderStore] saved \(order.orderNumber) · sync=\(order.syncState.rawValue)")
+        #endif
+    }
+
+    /// Todas las órdenes, más recientes primero.
+    func allOrders() -> [PurchaseOrder] {
+        loadIfNeeded()
+        return orders.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    /// Cuántas órdenes están pendientes de sincronizar.
+    func pendingSyncCount() -> Int {
+        loadIfNeeded()
+        return orders.filter { $0.syncState == .pendingSync }.count
+    }
+
+    /// Reconcilia las órdenes pendientes. Devuelve los IDs reconciliados.
+    /// Sólo actúa si hay conexión — si no, las deja pendientes.
+    @discardableResult
+    func syncPending(isOnline: Bool) -> [UUID] {
+        loadIfNeeded()
+        guard isOnline else { return [] }
+
+        var syncedIds: [UUID] = []
+        for idx in orders.indices where orders[idx].syncState == .pendingSync {
+            // NOTA: aquí iría el POST real a `/purchase-orders`. Sin endpoint
+            // de backend, reconciliamos el estado local — mismo patrón que
+            // `OfflineQueueService.drain()` para los productos.
+            orders[idx].syncState = .synced
+            syncedIds.append(orders[idx].id)
+        }
+        if !syncedIds.isEmpty {
+            persist()
+            #if DEBUG
+            print("[PurchaseOrderStore] synced \(syncedIds.count) pending order(s)")
+            #endif
+        }
+        return syncedIds
+    }
+
+    func clear() {
+        orders.removeAll()
+        try? fileManager.removeItem(at: storageURL())
+    }
+
+    // MARK: - Disk I/O
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        defer { loaded = true }
+        let url = storageURL()
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        if let data = try? Data(contentsOf: url),
+           let decoded = try? decoder.decode([PurchaseOrder].self, from: data) {
+            orders = decoded
+        }
+    }
+
+    private func persist() {
+        let url = storageURL()
+        if let data = try? encoder.encode(orders) {
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func storageURL() -> URL {
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        if !fileManager.fileExists(atPath: base.path) {
+            try? fileManager.createDirectory(at: base, withIntermediateDirectories: true)
+        }
+        return base.appendingPathComponent(fileName)
+    }
+}

--- a/Services/PurchaseOrders/SupplierPerformanceService.swift
+++ b/Services/PurchaseOrders/SupplierPerformanceService.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SupplierPerformanceService — Sprint 4. Computa el reporte de BQ11
+// (desempeño / volumen de órdenes por proveedor).
+//
+// El agregado corre en `Task.detached(.userInitiated)` para no bloquear el
+// @MainActor mientras se recorren las órdenes. Opera 100% sobre datos
+// locales (`PurchaseOrderStore`) — responde aunque no haya conexión.
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum SupplierPerformanceService {
+
+    /// Agrega las órdenes por proveedor. `Sendable` in / `Sendable` out, así
+    /// que es seguro correrlo en una tarea desprendida del main.
+    static func report(orders: [PurchaseOrder]) async -> SupplierPerformanceReport {
+        await Task.detached(priority: .userInitiated) {
+            let start = Date()
+
+            var bySupplier: [UUID: (name: String, orders: Int, items: Int,
+                                    total: Double, pending: Int)] = [:]
+            for order in orders {
+                var agg = bySupplier[order.supplierId]
+                    ?? (order.supplierName, 0, 0, 0, 0)
+                agg.name = order.supplierName
+                agg.orders += 1
+                agg.items += order.itemCount
+                agg.total += order.total
+                if order.syncState == .pendingSync { agg.pending += 1 }
+                bySupplier[order.supplierId] = agg
+            }
+
+            let suppliers = bySupplier
+                .map { id, agg in
+                    SupplierOrderStats(
+                        supplierId: id,
+                        supplierName: agg.name,
+                        orderCount: agg.orders,
+                        itemCount: agg.items,
+                        totalCommitted: agg.total,
+                        pendingSyncCount: agg.pending
+                    )
+                }
+                .sorted { $0.totalCommitted > $1.totalCommitted }
+
+            let totalCommitted = orders.reduce(0.0) { $0 + $1.total }
+            let pending = orders.filter { $0.syncState == .pendingSync }.count
+            let elapsed = Date().timeIntervalSince(start) * 1000
+
+            return SupplierPerformanceReport(
+                suppliers: suppliers,
+                totalOrders: orders.count,
+                totalCommitted: totalCommitted,
+                pendingSyncOrders: pending,
+                computedAt: Date(),
+                durationMs: elapsed
+            )
+        }.value
+    }
+}

--- a/Views/Analytics/Insights/WasteReportCard.swift
+++ b/Views/Analytics/Insights/WasteReportCard.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WasteReportCard — Sprint 4. Card de BQ10 (Santiago) en el dashboard de
+// Business Questions. Resume el valor de mermas por causa y por categoría.
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct WasteReportCard: View {
+    let report: WasteReport?
+    let isLoading: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if isLoading && report == nil {
+                loadingRow
+            } else if let r = report, r.totalEvents > 0 {
+                overall(r)
+                Divider()
+                reasonList(r.byReason.prefix(4))
+                footer(r)
+            } else {
+                emptyState
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.systemBackground))
+                .shadow(color: Color.black.opacity(0.04), radius: 6, y: 2)
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("BQ10 · Valor de mermas")
+                .font(.subheadline.weight(.semibold))
+            Text("Reporte cacheado (cache-aside + TTL + invalidación)")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func overall(_ r: WasteReport) -> some View {
+        HStack(spacing: 20) {
+            metricBlock(
+                label: "Valor perdido",
+                value: r.totalValueLost.compactCurrency,
+                color: .red
+            )
+            metricBlock(
+                label: "Unidades",
+                value: "\(r.totalUnitsLost)",
+                color: .primary
+            )
+            metricBlock(
+                label: "Eventos",
+                value: "\(r.totalEvents)",
+                color: .orange
+            )
+        }
+    }
+
+    private func metricBlock(label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.title3.weight(.bold))
+                .foregroundColor(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func reasonList(_ rows: ArraySlice<WasteReasonBreakdown>) -> some View {
+        VStack(spacing: 10) {
+            ForEach(Array(rows)) { row in
+                HStack {
+                    Image(systemName: row.reason.icon)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .frame(width: 22)
+                    Text(row.reason.rawValue)
+                        .font(.subheadline.weight(.medium))
+                    Spacer()
+                    Text("\(row.unitsLost) uds")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text(row.valueLost.compactCurrency)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.red)
+                }
+            }
+        }
+    }
+
+    private func footer(_ r: WasteReport) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: r.fromCache ? "bolt.fill" : "function").font(.caption2)
+            Text(r.fromCache
+                 ? "Servido desde caché · ventana \(r.windowDays) días"
+                 : String(format: "Computado en %.1f ms · ventana %d días",
+                          r.durationMs, r.windowDays))
+                .font(.caption2)
+        }
+        .foregroundColor(.secondary)
+    }
+
+    private var emptyState: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 6) {
+                Image(systemName: "trash.slash")
+                    .font(.title2)
+                    .foregroundColor(.secondary)
+                Text("Registra mermas (Inicio → Herramientas) para ver esta BQ.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.vertical, 20)
+            Spacer()
+        }
+    }
+
+    private var loadingRow: some View {
+        HStack {
+            Spacer()
+            ProgressView("Calculando mermas…").font(.footnote)
+            Spacer()
+        }
+        .padding(.vertical, 24)
+    }
+}


### PR DESCRIPTION
## Problema

`main` no compila tras los merges de #116 (Santiago) y #117 (Angel): cada PR
referencia archivos que no quedaron incluidos en el merge.

- `BusinessQuestionsView` monta `WasteReportCard` (BQ10), pero el archivo no está en el repo.
- `PurchaseOrderViewModel` y `SupplierBQViewModel` usan `PurchaseOrderStore.shared` y `SupplierPerformanceService`, pero la carpeta `Services/PurchaseOrders/` no está.

Errores de compilación:
- `cannot find 'WasteReportCard' in scope`
- `cannot find 'PurchaseOrderStore' in scope`
- `cannot find 'SupplierPerformanceService' in scope`

## Solución

Restaurar los 3 archivos. Sólo agregan; no modifican ningún otro archivo del repo.

## Participación

- **Santiago Orduz** — `WasteReportCard.swift` (card de BQ10, Registro de Mermas).
- **Angel Peñaranda** — `PurchaseOrderStore.swift` y `SupplierPerformanceService.swift` (persistencia + Eventual Connectivity y agregación de BQ11, Órdenes de Compra).
- **Juan Felipe Ledesma** — integración del fix y verificación de build.

## Verificación

- Debug → **BUILD SUCCEEDED**
- Release → **BUILD SUCCEEDED**

## Test plan
- [ ] Business Questions muestra las cards de BQ9, BQ10 y BQ11.
- [ ] Inicio → Herramientas → "Registro de Mermas" y "Órdenes de Compra" abren sin crash.