### PR TITLE
fix(offline): sincronizar productos automaticamente al volver la red

### DIFF
--- a/Services/Connectivity/OfflineQueueService.swift
+++ b/Services/Connectivity/OfflineQueueService.swift
@@ -120,6 +120,16 @@ actor OfflineQueueService {
         persist()
     }
 
+    /// Fuerza un drain inmediato de la cola. Idempotente: si ya hay un drain
+    /// corriendo o la cola está vacía, retorna sin hacer nada. Pensado para
+    /// que la UI pueda reintentar explícitamente cuando vuelve la red,
+    /// como belt-and-suspenders del trigger automático por `onTransition`.
+    /// (El trigger automático puede llegar antes de que `NetworkMonitor`
+    /// publique el cambio, con lo que la primera pasada del replay falla.)
+    func flushNow() async {
+        await drain()
+    }
+
     struct ReplayHandlers {
         var createProduct: (Product) async throws -> Product
         var updateProduct: (UUID, Product) async throws -> Product
@@ -150,6 +160,45 @@ actor OfflineQueueService {
         print("[OfflineQueue] draining \(items.count) operation(s)")
         #endif
 
+        var syncedProductIds = await replayPass(handlers: handlers)
+
+        // Si quedaron operaciones tras la primera pasada (típicamente porque
+        // la red apenas se está estabilizando tras un toggle de modo avión y
+        // el guard de `ProductRepository` rebotó con `APIError.offline`),
+        // esperamos 2s y reintentamos UNA vez. Sin este retry el usuario
+        // tendría que hacer otra transición de red — o editar el producto
+        // a mano — para que se sincronice.
+        if !items.isEmpty {
+            #if DEBUG
+            print("[OfflineQueue] \(items.count) remaining after first pass — retrying in 2s")
+            #endif
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            let retryIds = await replayPass(handlers: handlers)
+            syncedProductIds.append(contentsOf: retryIds)
+        }
+
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.lastDrainKey)
+
+        // Snapshot inmutable antes de cruzar al MainActor: evita el warning
+        // "reference to captured var in concurrently-executing code" que en
+        // Swift 6 se convierte en error.
+        let idsToBroadcast = syncedProductIds
+        if !idsToBroadcast.isEmpty {
+            await MainActor.run {
+                NotificationCenter.default.post(
+                    name: .inventoryDidSync,
+                    object: nil,
+                    userInfo: ["syncedProductIds": idsToBroadcast]
+                )
+            }
+        }
+    }
+
+    /// Una pasada del replay sobre `items`. Mutación in-place de `items` con
+    /// las operaciones que quedan pendientes (fallidas). Devuelve los IDs
+    /// que sí lograron sincronizarse en esta pasada — el caller los acumula
+    /// para postear `.inventoryDidSync` al final.
+    private func replayPass(handlers: ReplayHandlers) async -> [UUID] {
         var remaining: [QueuedOperation] = []
         var syncedProductIds: [UUID] = []
         for op in items {
@@ -174,19 +223,7 @@ actor OfflineQueueService {
         }
         items = remaining
         persist()
-
-        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: Self.lastDrainKey)
-
-       
-        if !syncedProductIds.isEmpty {
-            await MainActor.run {
-                NotificationCenter.default.post(
-                    name: .inventoryDidSync,
-                    object: nil,
-                    userInfo: ["syncedProductIds": syncedProductIds]
-                )
-            }
-        }
+        return syncedProductIds
     }
 
     private func loadIfNeeded() {

--- a/Services/Repositories/ProductRepository.swift
+++ b/Services/Repositories/ProductRepository.swift
@@ -14,10 +14,17 @@ protocol ProductRepositoryProtocol {
 final class ProductRepository: ProductRepositoryProtocol {
     private let apiClient = APIClient.shared
     private let cache = PersistenceService.shared
-    private let networkMonitor = NetworkMonitor.shared
+    // Para el estado de conectividad usamos `ConnectivityService` (no
+    // `NetworkMonitor`) porque es el MISMO publisher que dispara el drain
+    // del `OfflineQueueService`. Tener dos `NWPathMonitor` independientes
+    // creaba una carrera offline→online: el drain ejecutaba el replay
+    // mientras `NetworkMonitor.isConnected` aún era `false`, el guard
+    // tiraba `APIError.offline`, y la op quedaba re-encolada sin reintento.
+    // Alineando ambas comprobaciones contra `ConnectivityService.isOnline`
+    // el replay ya no falsea-falla en la transición.
 
     func fetchProducts(search: String? = nil, category: String? = nil, stockStatus: String? = nil, limit: Int? = nil, cursor: String? = nil) async throws -> (products: [Product], nextCursor: String?) {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             return (cache.loadProducts(), nil)
         }
 
@@ -44,7 +51,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func getProduct(id: String) async throws -> Product {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             if let cached = cache.loadProducts().first(where: { $0.id == UUID(deterministicFrom: id) }) {
                 return cached
             }
@@ -56,7 +63,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func createProduct(_ product: Product) async throws -> Product {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             throw APIError.offline
         }
 
@@ -78,7 +85,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func updateProduct(id: String, _ product: Product) async throws -> Product {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             throw APIError.offline
         }
 
@@ -102,7 +109,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func deleteProduct(id: String) async throws {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             throw APIError.offline
         }
 
@@ -118,7 +125,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func fetchLowStock() async throws -> [Product] {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             return cache.loadProducts().filter { $0.stockStatus == .lowStock }
         }
 
@@ -127,7 +134,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func fetchOutOfStock() async throws -> [Product] {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             return cache.loadProducts().filter { $0.stockStatus == .outOfStock }
         }
 
@@ -136,7 +143,7 @@ final class ProductRepository: ProductRepositoryProtocol {
     }
 
     func fetchExpiringSoon(days: Int = 30) async throws -> [Product] {
-        guard networkMonitor.isConnected else {
+        guard ConnectivityService.shared.isOnline else {
             return cache.loadProducts().filter { $0.isExpiringSoon }
         }
 

--- a/ViewModels/InventoryViewModel.swift
+++ b/ViewModels/InventoryViewModel.swift
@@ -56,6 +56,7 @@ class InventoryViewModel: ObservableObject {
     private let networkMonitor = NetworkMonitor.shared
     private var logoutObserver: Any?
     private var syncObserver: Any?
+    private var cancellables: Set<AnyCancellable> = []
 
     enum StockFilter: String, CaseIterable {
         case all = "Todos"
@@ -95,6 +96,24 @@ class InventoryViewModel: ObservableObject {
             guard let ids = note.userInfo?["syncedProductIds"] as? [UUID] else { return }
             Task { @MainActor in self?.markProductsSynced(ids: ids) }
         }
+
+        // Belt-and-suspenders del auto-sync. `OfflineQueueService` ya escucha
+        // `onTransition` y dispara su propio `drain` apenas vuelve la red.
+        // Aquí agregamos un SEGUNDO trigger explícito 1.5s después de la
+        // transición, por si la primera pasada del replay falló y/o si la
+        // suscripción del store nunca llegó a configurarse (p.ej. después de
+        // un cold start con la cola ya cargada). `flushNow` es idempotente:
+        // si la cola está vacía, no hace nada.
+        ConnectivityService.shared.onTransition
+            .filter { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                Task {
+                    try? await Task.sleep(nanoseconds: 1_500_000_000)
+                    await OfflineQueueService.shared.flushNow()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     deinit {


### PR DESCRIPTION
## Bug

Al activar modo avión durante la creación de un producto, el producto queda en `.pendingCreate`. **Cuando se desactiva el modo avión, el producto NO se sube automáticamente** — había que editarlo y guardarlo a mano para que se sincronizara.

## Causa raíz

`OfflineQueueService.drain` se dispara con `ConnectivityService.onTransition`. Cada operación del replay invoca `ProductRepository.{create,update,delete}Product`, que tenía un guard:

```swift
guard networkMonitor.isConnected else { throw APIError.offline }
```

`NetworkMonitor` es **otra** instancia de `NWPathMonitor`, independiente de `ConnectivityService`, y se actualiza asincrónicamente. En la transición offline→online puede estar todavía en `false` durante una fracción de segundo. Resultado:

1. `ConnectivityService` emite `onTransition(true)` → `drain()` corre.
2. El replay invoca `createProduct(product)`.
3. `NetworkMonitor.isConnected` aún es `false` → guard tira `APIError.offline`.
4. La op se re-encola, pero como ya no hay más transiciones, **no hay más reintentos** hasta que el usuario haga algo manualmente.

Por eso "editar y guardar" lo arreglaba: en ese momento la red ya había estabilizado.

## Cambios

### 1. `ProductRepository`
Unifica los 8 guards de conectividad a `ConnectivityService.shared.isOnline` (la misma fuente que dispara el drain). Elimina la carrera.

### 2. `OfflineQueueService`
- Nuevo método público **`flushNow()`** que invoca `drain()` (idempotente).
- `drain()` ahora hace una pasada y, **si quedan ops pendientes, espera 2s y reintenta una vez más** — cubre errores transitorios en el momento exacto de la transición.
- Refactor menor: la lógica del replay sale a `replayPass(handlers:)` para no duplicar entre la primera pasada y el retry.
- Snapshot inmutable de los IDs antes de cruzar al MainActor (evita warning Swift-6 de captura de var en closure `@Sendable`).

### 3. `InventoryViewModel`
**Belt-and-suspenders.** Además del drain automático del `OfflineQueueService`, la VM también se suscribe a `onTransition` y, 1.5s después de volver online, llama `flushNow()` explícitamente. Cubre:
- Cold-starts con cola cargada (donde la PassthroughSubject no replay-ea).
- Cualquier pérdida del primer trigger.

## Demo (después de mergear)

1. Iniciar sesión.
2. **Activar modo avión.**
3. Crear un producto nuevo → aparece con badge "pendiente" (⏳).
4. **Desactivar modo avión.**
5. En ~1.5–2 segundos el badge desaparece solo, sin tocar nada. El producto ya está en el backend.

## Verificación

- Debug → **BUILD SUCCEEDED**, 0 errores, 0 warnings nuevos.
- Release → **BUILD SUCCEEDED**, 0 errores.

## Test plan
- [ ] Modo avión ON → crear producto → badge "pendiente" visible.
- [ ] Modo avión OFF → en <3s el badge desaparece sin intervención.
- [ ] Sin internet → editar producto existente → al volver red, cambios se suben solos.
- [ ] Sin internet → eliminar producto → al volver red, eliminación se ejecuta sola.